### PR TITLE
feat: add combined Codex and Claude Telegram bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,18 @@
 # Binaries
 /bot
 /rcod
+/codexbot
 /remote-control-on-demand
 *.exe
 dist/
 
 # Config with secrets
 config.yaml
+codex_sessions.json
+.gocache/
+.gomodcache/
+.gotmp/
+.codexbot/
 
 # IDE
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Git Conventions
 
-**Commits:** [Conventional Commits](https://www.conventionalcommits.org/) — enforced by commitlint in CI. Prefixes: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `perf:`, `style:`, `ci:`, `build:`.
+**Commits:** [Conventional Commits](https://www.conventionalcommits.org/) — enforced by commitlint in CI.
+
+- AI-generated commits must always pass commitlint.
+- AI-generated commits may only use the prefixes `feat:` or `fix:`.
+- Prefer `feat:` for new behavior and `fix:` for regressions, bugs, and repair work.
 
 **Branches:** `{type}/{issue-number}-short-description` when working on a GitHub issue, e.g. `feat/42-session-auto-cleanup`. Without an issue: `{type}/short-description`, e.g. `fix/crash-on-empty-config`.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Manage [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions remotely via Telegram. RCOD runs on your machine or server, starts `claude rc` inside selected git repositories, and sends status, logs, crashes, and Claude session links back to your phone.
 
+This repo also includes a Codex-focused Telegram bot that lets you chat with Codex directly inside a selected repository.
+
 Built by [zevro.ai](https://zevro.ai).
 
 ![RCOD demo](./docs/assets/rcod-demo.gif)
@@ -22,6 +24,32 @@ Built by [zevro.ai](https://zevro.ai).
 - Paginates repository pickers and supports unique partial project matches
 - Always launches Claude with `--permission-mode bypassPermissions`
 
+## Codex Telegram Chat
+
+The `cmd/codexbot` entrypoint exposes Telegram as a chat interface for Codex:
+
+- create a Codex chat session for a repo with `/new` or `/folders`
+- switch between chat sessions with `/sessions` and `/use`
+- send a normal Telegram message to talk to Codex in the active repo
+- close old chat threads with `/close`
+- Codex respects `rc.permission_mode` from `config.yaml`; default is `workspace-write`, `bypassPermissions` opts into full local access, and other accepted values map to Codex sandbox modes
+
+Build and run it with:
+
+```bash
+go build -o codexbot ./cmd/codexbot
+./codexbot -config config.yaml
+```
+
+For local native control helpers:
+
+```bash
+scripts/start-codexbot-native.sh config.yaml
+scripts/status-codexbot-native.sh
+scripts/reset-codexbot-native.sh config.yaml
+scripts/install-codexbot-native-launchd.sh config.yaml
+```
+
 ## How It Works
 
 ```text
@@ -35,10 +63,12 @@ You (Telegram) -> RCOD bot -> claude rc (inside your git repo)
 | --- | --- |
 | Go 1.25+ | Needed only when building from source |
 | Claude Code CLI | Install with `npm install -g @anthropic-ai/claude-code` |
+| Codex CLI | Needed for `cmd/codexbot`; install it and keep `codex` in your `PATH` |
 | Telegram bot token | Create one via [@BotFather](https://t.me/BotFather) |
 | Telegram user ID | Get it from [@userinfobot](https://t.me/userinfobot) |
 
 `claude` must be available in your `PATH`.
+For `codexbot`, `codex` must also be available in your `PATH`.
 
 ## Quick Start
 
@@ -69,6 +99,7 @@ telegram:
 
 rc:
   base_folder: "/home/user/Projects"
+  permission_mode: "workspace-write"
   auto_restart: true
   max_restarts: 3
   restart_delay_seconds: 5
@@ -83,6 +114,7 @@ See [config.example.yaml](./config.example.yaml) for a fuller example with notif
 | `telegram.token` | Bot token from @BotFather |
 | `telegram.allowed_user_id` | Only this Telegram user can control the bot |
 | `rc.base_folder` | Directory RCOD scans for git repositories |
+| `rc.permission_mode` | Codex bot access mode: `workspace-write` (default), `read-only`, `danger-full-access`, or `bypassPermissions` |
 | `rc.auto_restart` | Enables automatic restart for crashed sessions |
 | `rc.max_restarts` | Maximum restart attempts before giving up |
 | `rc.restart_delay_seconds` | Delay between restart attempts |

--- a/cmd/codexbot/main.go
+++ b/cmd/codexbot/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/zevro-ai/remote-control-on-demand/internal/codex"
+	"github.com/zevro-ai/remote-control-on-demand/internal/codexbot"
+	"github.com/zevro-ai/remote-control-on-demand/internal/config"
+	"github.com/zevro-ai/remote-control-on-demand/internal/process"
+	"github.com/zevro-ai/remote-control-on-demand/internal/session"
+)
+
+const (
+	esc = "\033["
+	r   = esc + "0m"
+	b1  = esc + "1m"
+	dim = esc + "2m"
+	ylw = esc + "33m"
+	whi = esc + "97m"
+	byl = esc + "93m"
+)
+
+func printBanner() {
+	c := byl
+	w := b1 + whi
+	d := dim
+
+	fmt.Println()
+	fmt.Println(c + "    ██████╗ ██████╗ ██████╗ ███████╗██╗  ██╗" + r)
+	fmt.Println(c + "   ██╔════╝██╔═══██╗██╔══██╗██╔════╝╚██╗██╔╝" + r)
+	fmt.Println(c + "   ██║     ██║   ██║██║  ██║█████╗   ╚███╔╝ " + r)
+	fmt.Println(c + "   ██║     ██║   ██║██║  ██║██╔══╝   ██╔██╗ " + r)
+	fmt.Println(c + "   ╚██████╗╚██████╔╝██████╔╝███████╗██╔╝ ██╗" + r)
+	fmt.Println(c + "    ╚═════╝ ╚═════╝ ╚═════╝ ╚══════╝╚═╝  ╚═╝" + r)
+	fmt.Println()
+	fmt.Println(w + "    Codex Telegram Bot" + r)
+	fmt.Println(d + "    Chat with Codex inside your repositories" + r)
+	fmt.Println()
+	fmt.Println(ylw + "    ● " + r + "Bot is running" + d + "              Ctrl+C to stop" + r)
+	fmt.Println()
+}
+
+func main() {
+	configPath := flag.String("config", "config.yaml", "path to config file")
+	flag.Parse()
+
+	var cfg *config.Config
+	var err error
+
+	if !config.Exists(*configPath) {
+		cfg, err = config.RunOnboarding(*configPath)
+		if err != nil {
+			log.Fatalf("Onboarding failed: %v", err)
+		}
+	} else {
+		cfg, err = config.Load(*configPath)
+		if err != nil {
+			log.Fatalf("Loading config: %v", err)
+		}
+	}
+
+	runner := process.NewRunner()
+	sessionStatePath := filepath.Join(filepath.Dir(*configPath), "sessions.json")
+	sessionMgr := session.NewManager(
+		runner,
+		cfg.RC.BaseFolder,
+		sessionStatePath,
+		cfg.RC.AutoRestart,
+		cfg.RC.MaxRestarts,
+		time.Duration(cfg.RC.RestartDelaySeconds)*time.Second,
+		cfg.RC.Notifications,
+	)
+	if err := sessionMgr.Restore(); err != nil {
+		log.Printf("Warning: Failed to restore Claude sessions: %v", err)
+	}
+
+	codexStatePath := filepath.Join(filepath.Dir(*configPath), "codex_sessions.json")
+	codexMgr := codex.NewManager(cfg.RC.BaseFolder, codexStatePath)
+	codexMgr.ConfigurePermissionMode(cfg.RC.PermissionMode)
+	if err := codexMgr.Restore(); err != nil {
+		log.Fatalf("Restoring Codex sessions: %v", err)
+	}
+
+	bt, err := codexbot.New(cfg.Telegram.Token, cfg.Telegram.AllowedUserID, sessionMgr, codexMgr)
+	if err != nil {
+		log.Fatalf("Creating bot: %v", err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		<-sigCh
+		fmt.Println()
+		fmt.Println(dim + "    Shutting down..." + r)
+		stopped := sessionMgr.StopAll()
+		bt.SendMessage(fmt.Sprintf("<b>RCOD + Codex bot stopped.</b>\nClosed Claude sessions: <code>%d</code>", stopped))
+		bt.Stop()
+	}()
+
+	printBanner()
+	bt.Start()
+}

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,1 +1,6 @@
-export default { extends: ['@commitlint/config-conventional'] };
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [2, 'always', ['feat', 'fix']],
+  },
+};

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,6 +4,7 @@ telegram:
 
 rc:
   base_folder: "/home/user/Projects"
+  permission_mode: "workspace-write"  # codexbot only; use bypassPermissions only for full local access
   auto_restart: true
   max_restarts: 3
   restart_delay_seconds: 5

--- a/internal/codex/manager.go
+++ b/internal/codex/manager.go
@@ -1,0 +1,701 @@
+package codex
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/zevro-ai/remote-control-on-demand/internal/config"
+)
+
+const (
+	defaultSandbox                  = "workspace-write"
+	defaultDangerouslyBypassSandbox = false
+	defaultSystemPATH               = "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin"
+)
+
+type Session struct {
+	ID        string    `json:"id"`
+	Folder    string    `json:"folder"`
+	RelName   string    `json:"rel_name"`
+	ThreadID  string    `json:"thread_id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Busy      bool      `json:"-"`
+}
+
+type state struct {
+	ActiveSessionID string     `json:"active_session_id"`
+	Sessions        []*Session `json:"sessions"`
+}
+
+type Manager struct {
+	mu                       sync.Mutex
+	baseFolder               string
+	statePath                string
+	sessions                 map[string]*Session
+	activeSessionID          string
+	model                    string
+	sandbox                  string
+	dangerouslyBypassSandbox bool
+}
+
+func NewManager(baseFolder, statePath string) *Manager {
+	return &Manager{
+		baseFolder:               baseFolder,
+		statePath:                statePath,
+		sessions:                 make(map[string]*Session),
+		sandbox:                  defaultSandbox,
+		dangerouslyBypassSandbox: defaultDangerouslyBypassSandbox,
+	}
+}
+
+func (m *Manager) Restore() error {
+	if m.statePath == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(m.statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading codex state: %w", err)
+	}
+
+	var saved state
+	if err := json.Unmarshal(data, &saved); err != nil {
+		return fmt.Errorf("parsing codex state: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.activeSessionID = saved.ActiveSessionID
+	m.sessions = make(map[string]*Session, len(saved.Sessions))
+	for _, sess := range saved.Sessions {
+		if sess == nil || sess.ID == "" {
+			continue
+		}
+		sess.Busy = false
+		m.sessions[sess.ID] = sess
+	}
+	if _, ok := m.sessions[m.activeSessionID]; !ok {
+		m.activeSessionID = ""
+	}
+
+	return nil
+}
+
+func (m *Manager) SetModel(model string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.model = strings.TrimSpace(model)
+}
+
+func (m *Manager) SetSandbox(sandbox string) {
+	sandbox = strings.TrimSpace(sandbox)
+	if sandbox == "" {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sandbox = sandbox
+}
+
+func (m *Manager) SetDangerouslyBypassSandbox(enabled bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dangerouslyBypassSandbox = enabled
+}
+
+func (m *Manager) ConfigurePermissionMode(permissionMode string) {
+	permissionMode = config.NormalizeCodexPermissionMode(permissionMode)
+	if permissionMode == config.PermissionModeBypass {
+		m.SetDangerouslyBypassSandbox(true)
+		m.SetSandbox(defaultSandbox)
+		return
+	}
+
+	m.SetDangerouslyBypassSandbox(false)
+	m.SetSandbox(permissionMode)
+}
+
+func (m *Manager) BaseFolder() string {
+	return m.baseFolder
+}
+
+func (m *Manager) Create(folder string) (*Session, error) {
+	fullPath, relName, err := resolveProjectPath(m.baseFolder, folder)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := os.Stat(fullPath)
+	if err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("folder %q does not exist", relName)
+	}
+
+	if _, err := os.Stat(filepath.Join(fullPath, ".git")); err != nil {
+		return nil, fmt.Errorf("folder %q is not a git repository", relName)
+	}
+
+	id, err := generateID()
+	if err != nil {
+		return nil, fmt.Errorf("generating session ID: %w", err)
+	}
+
+	now := time.Now()
+	sess := &Session{
+		ID:        id,
+		Folder:    fullPath,
+		RelName:   relName,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.sessions[id] = sess
+	m.activeSessionID = id
+	if err := m.saveLocked(); err != nil {
+		return nil, err
+	}
+
+	return cloneSession(sess), nil
+}
+
+func (m *Manager) List() []*Session {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	list := make([]*Session, 0, len(m.sessions))
+	for _, sess := range m.sessions {
+		list = append(list, cloneSession(sess))
+	}
+
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].ID == m.activeSessionID {
+			return true
+		}
+		if list[j].ID == m.activeSessionID {
+			return false
+		}
+		return list[i].UpdatedAt.After(list[j].UpdatedAt)
+	})
+
+	return list
+}
+
+func (m *Manager) Get(id string) (*Session, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sess, ok := m.sessions[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneSession(sess), true
+}
+
+func (m *Manager) Active() (*Session, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.activeSessionID == "" {
+		return nil, false
+	}
+	sess, ok := m.sessions[m.activeSessionID]
+	if !ok {
+		return nil, false
+	}
+	return cloneSession(sess), true
+}
+
+func (m *Manager) SetActive(id string) (*Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sess, ok := m.sessions[id]
+	if !ok {
+		return nil, fmt.Errorf("session %q not found", id)
+	}
+
+	m.activeSessionID = id
+	sess.UpdatedAt = time.Now()
+	if err := m.saveLocked(); err != nil {
+		return nil, err
+	}
+
+	return cloneSession(sess), nil
+}
+
+func (m *Manager) Close(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.sessions[id]; !ok {
+		return fmt.Errorf("session %q not found", id)
+	}
+
+	delete(m.sessions, id)
+	if m.activeSessionID == id {
+		m.activeSessionID = ""
+	}
+	if len(m.sessions) == 1 && m.activeSessionID == "" {
+		for sessionID := range m.sessions {
+			m.activeSessionID = sessionID
+		}
+	}
+
+	return m.saveLocked()
+}
+
+func (m *Manager) ResolveActive() (*Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.activeSessionID != "" {
+		sess, ok := m.sessions[m.activeSessionID]
+		if ok {
+			return cloneSession(sess), nil
+		}
+		m.activeSessionID = ""
+	}
+
+	if len(m.sessions) == 1 {
+		for id, sess := range m.sessions {
+			m.activeSessionID = id
+			_ = m.saveLocked()
+			return cloneSession(sess), nil
+		}
+	}
+
+	if len(m.sessions) == 0 {
+		return nil, fmt.Errorf("no Codex session yet; use /new or /folders first")
+	}
+
+	return nil, fmt.Errorf("no active session selected; use /use or /sessions")
+}
+
+func (m *Manager) Send(id, prompt string) (*Session, string, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil, "", fmt.Errorf("message cannot be empty")
+	}
+
+	m.mu.Lock()
+	sess, ok := m.sessions[id]
+	if !ok {
+		m.mu.Unlock()
+		return nil, "", fmt.Errorf("session %q not found", id)
+	}
+	if sess.Busy {
+		m.mu.Unlock()
+		return nil, "", fmt.Errorf("session %q is already processing another message", id)
+	}
+
+	sess.Busy = true
+	sandbox := m.sandbox
+	dangerouslyBypassSandbox := m.dangerouslyBypassSandbox
+	model := m.model
+	snapshot := cloneSession(sess)
+	m.mu.Unlock()
+
+	threadID, reply, err := runCodex(snapshot, prompt, sandbox, model, dangerouslyBypassSandbox)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	current, ok := m.sessions[id]
+	if !ok {
+		return nil, "", fmt.Errorf("session %q disappeared while processing", id)
+	}
+
+	current.Busy = false
+	current.UpdatedAt = time.Now()
+	if threadID != "" {
+		current.ThreadID = threadID
+	}
+	saveErr := m.saveLocked()
+	if err != nil {
+		if saveErr != nil {
+			return nil, "", fmt.Errorf("%w (state save failed: %v)", err, saveErr)
+		}
+		return nil, "", err
+	}
+	if saveErr != nil {
+		return nil, "", saveErr
+	}
+
+	return cloneSession(current), reply, nil
+}
+
+func runCodex(sess *Session, prompt, sandbox, model string, dangerouslyBypassSandbox bool) (string, string, error) {
+	codexBin, cmdEnv, err := resolveCodexCommandEnv()
+	if err != nil {
+		return "", "", fmt.Errorf("starting codex: %w", err)
+	}
+
+	args := buildCodexArgs(sess, prompt, sandbox, model, dangerouslyBypassSandbox)
+	cmd := exec.CommandContext(context.Background(), codexBin, args...)
+	cmd.Dir = sess.Folder
+	cmd.Env = cmdEnv
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", "", fmt.Errorf("creating stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return "", "", fmt.Errorf("creating stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return "", "", fmt.Errorf("starting codex: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	var result execResult
+	var stdoutBuf strings.Builder
+	var stderrBuf strings.Builder
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		parseExecOutput(stdout, &result, &stdoutBuf)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&stderrBuf, stderr)
+	}()
+
+	waitErr := cmd.Wait()
+	wg.Wait()
+
+	if waitErr != nil {
+		detail := strings.TrimSpace(stderrBuf.String())
+		if detail == "" {
+			detail = strings.TrimSpace(stdoutBuf.String())
+		}
+		if detail == "" {
+			detail = waitErr.Error()
+		}
+		return result.ThreadID, strings.TrimSpace(result.Response), fmt.Errorf("codex command failed: %s", detail)
+	}
+
+	reply := strings.TrimSpace(result.Response)
+	if reply == "" {
+		reply = strings.TrimSpace(stdoutBuf.String())
+	}
+	if reply == "" {
+		return result.ThreadID, "", fmt.Errorf("codex returned an empty response")
+	}
+
+	return result.ThreadID, reply, nil
+}
+
+func buildCodexArgs(sess *Session, prompt, sandbox, model string, dangerouslyBypassSandbox bool) []string {
+	args := []string{"exec"}
+	if dangerouslyBypassSandbox {
+		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
+	}
+
+	if sess.ThreadID == "" {
+		args = append(args, "--json")
+		if !dangerouslyBypassSandbox {
+			args = append(args, "--sandbox", sandbox)
+		}
+		if model != "" {
+			args = append(args, "--model", model)
+		}
+		args = append(args, initialPrompt(sess, prompt))
+		return args
+	}
+
+	args = append(args, "resume", "--json")
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	args = append(args, sess.ThreadID, prompt)
+	return args
+}
+
+func initialPrompt(sess *Session, prompt string) string {
+	return fmt.Sprintf(
+		"You are Codex talking to the user through Telegram.\nKeep replies concise unless the user asks for depth.\nThis chat session is attached to repository %q.\n\nUser message:\n%s",
+		sess.RelName,
+		prompt,
+	)
+}
+
+type execResult struct {
+	ThreadID string
+	Response string
+}
+
+type execEvent struct {
+	Type     string `json:"type"`
+	ThreadID string `json:"thread_id,omitempty"`
+	Item     struct {
+		Type string `json:"type,omitempty"`
+		Text string `json:"text,omitempty"`
+	} `json:"item,omitempty"`
+}
+
+func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		raw.WriteString(line)
+		raw.WriteByte('\n')
+
+		var event execEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+
+		if event.ThreadID != "" {
+			result.ThreadID = event.ThreadID
+		}
+		if event.Type == "item.completed" && event.Item.Type == "agent_message" && event.Item.Text != "" {
+			result.Response = event.Item.Text
+		}
+	}
+}
+
+func (m *Manager) saveLocked() error {
+	if m.statePath == "" {
+		return nil
+	}
+
+	sessions := make([]*Session, 0, len(m.sessions))
+	for _, sess := range m.sessions {
+		copy := cloneSession(sess)
+		copy.Busy = false
+		sessions = append(sessions, copy)
+	}
+
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].CreatedAt.Before(sessions[j].CreatedAt)
+	})
+
+	data, err := json.MarshalIndent(state{
+		ActiveSessionID: m.activeSessionID,
+		Sessions:        sessions,
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling codex state: %w", err)
+	}
+
+	if err := os.WriteFile(m.statePath, data, 0600); err != nil {
+		return fmt.Errorf("writing codex state: %w", err)
+	}
+
+	return nil
+}
+
+func cloneSession(sess *Session) *Session {
+	if sess == nil {
+		return nil
+	}
+	copy := *sess
+	return &copy
+}
+
+func resolveProjectPath(baseFolder, folder string) (string, string, error) {
+	if strings.TrimSpace(folder) == "" {
+		return "", "", fmt.Errorf("folder is required")
+	}
+
+	baseAbs, err := filepath.Abs(baseFolder)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving base folder: %w", err)
+	}
+
+	targetAbs, err := filepath.Abs(filepath.Join(baseAbs, filepath.Clean(folder)))
+	if err != nil {
+		return "", "", fmt.Errorf("resolving folder %q: %w", folder, err)
+	}
+
+	relPath, err := filepath.Rel(baseAbs, targetAbs)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving folder %q: %w", folder, err)
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
+		return "", "", fmt.Errorf("folder %q must stay within rc.base_folder", folder)
+	}
+
+	return targetAbs, relPath, nil
+}
+
+func generateID() (string, error) {
+	b := make([]byte, 2)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func resolveCodexCommandEnv() (string, []string, error) {
+	codexBin, err := resolveCodexBinary()
+	if err != nil {
+		return "", nil, err
+	}
+
+	env := withPATH(os.Environ(), filepath.Dir(codexBin))
+	env = ensureHome(env)
+	return codexBin, env, nil
+}
+
+func resolveCodexBinary() (string, error) {
+	if configured := strings.TrimSpace(os.Getenv("CODEX_BIN")); configured != "" {
+		path, err := validateExecutable(configured)
+		if err != nil {
+			return "", fmt.Errorf("CODEX_BIN=%q is invalid: %w", configured, err)
+		}
+		return path, nil
+	}
+
+	if path, err := exec.LookPath("codex"); err == nil {
+		return path, nil
+	}
+
+	for _, candidate := range codexCandidatePaths() {
+		if path, err := validateExecutable(candidate); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find codex in PATH or common install locations")
+}
+
+func codexCandidatePaths() []string {
+	var candidates []string
+	seen := make(map[string]bool)
+
+	addCandidate := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		candidates = append(candidates, path)
+	}
+
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		addCandidate(filepath.Join(dir, "codex"))
+	}
+
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		for _, pattern := range []string{
+			filepath.Join(home, ".nvm", "versions", "node", "*", "bin", "codex"),
+			filepath.Join(home, ".volta", "bin", "codex"),
+			filepath.Join(home, ".local", "bin", "codex"),
+		} {
+			matches, _ := filepath.Glob(pattern)
+			sort.Sort(sort.Reverse(sort.StringSlice(matches)))
+			for _, match := range matches {
+				addCandidate(match)
+			}
+		}
+	}
+
+	for _, dir := range []string{"/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"} {
+		addCandidate(filepath.Join(dir, "codex"))
+	}
+
+	return candidates
+}
+
+func validateExecutable(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("path is a directory")
+	}
+	if info.Mode()&0111 == 0 {
+		return "", fmt.Errorf("path is not executable")
+	}
+	return path, nil
+}
+
+func withPATH(env []string, preferredDir string) []string {
+	pathEntries := []string{preferredDir}
+	pathEntries = append(pathEntries, filepath.SplitList(envValue(env, "PATH"))...)
+	pathEntries = append(pathEntries, filepath.SplitList(defaultSystemPATH)...)
+	return setEnv(env, "PATH", joinUniquePath(pathEntries))
+}
+
+func ensureHome(env []string) []string {
+	if strings.TrimSpace(envValue(env, "HOME")) != "" {
+		return env
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return env
+	}
+	return setEnv(env, "HOME", home)
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
+}
+
+func setEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	replaced := false
+	next := make([]string, 0, len(env)+1)
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			if !replaced {
+				next = append(next, prefix+value)
+				replaced = true
+			}
+			continue
+		}
+		next = append(next, entry)
+	}
+	if !replaced {
+		next = append(next, prefix+value)
+	}
+	return next
+}
+
+func joinUniquePath(entries []string) string {
+	seen := make(map[string]bool)
+	unique := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" || seen[entry] {
+			continue
+		}
+		seen[entry] = true
+		unique = append(unique, entry)
+	}
+	return strings.Join(unique, string(os.PathListSeparator))
+}

--- a/internal/codex/manager_test.go
+++ b/internal/codex/manager_test.go
@@ -1,0 +1,102 @@
+package codex
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildCodexArgsNewSessionDangerousBypass(t *testing.T) {
+	sess := &Session{RelName: "remote-control-on-demand"}
+
+	got := buildCodexArgs(sess, "Wystaw PR", "workspace-write", "gpt-5", true)
+	want := []string{
+		"exec",
+		"--dangerously-bypass-approvals-and-sandbox",
+		"--json",
+		"--model",
+		"gpt-5",
+		initialPrompt(sess, "Wystaw PR"),
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildCodexArgs() mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestBuildCodexArgsNewSessionSandboxed(t *testing.T) {
+	sess := &Session{RelName: "remote-control-on-demand"}
+
+	got := buildCodexArgs(sess, "Wystaw PR", "workspace-write", "gpt-5", false)
+	want := []string{
+		"exec",
+		"--json",
+		"--sandbox",
+		"workspace-write",
+		"--model",
+		"gpt-5",
+		initialPrompt(sess, "Wystaw PR"),
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildCodexArgs() mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestBuildCodexArgsResumeDangerousBypass(t *testing.T) {
+	sess := &Session{
+		RelName:  "remote-control-on-demand",
+		ThreadID: "thread-123",
+	}
+
+	got := buildCodexArgs(sess, "Działaj", "workspace-write", "gpt-5", true)
+	want := []string{
+		"exec",
+		"--dangerously-bypass-approvals-and-sandbox",
+		"resume",
+		"--json",
+		"--model",
+		"gpt-5",
+		"thread-123",
+		"Działaj",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildCodexArgs() mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestConfigurePermissionModeDangerousBypass(t *testing.T) {
+	mgr := NewManager("/tmp/projects", "")
+	mgr.ConfigurePermissionMode("bypassPermissions")
+
+	if !mgr.dangerouslyBypassSandbox {
+		t.Fatal("expected dangerouslyBypassSandbox to stay enabled")
+	}
+	if mgr.sandbox != defaultSandbox {
+		t.Fatalf("expected sandbox to remain %q, got %q", defaultSandbox, mgr.sandbox)
+	}
+}
+
+func TestConfigurePermissionModeDefaultSandbox(t *testing.T) {
+	mgr := NewManager("/tmp/projects", "")
+	mgr.ConfigurePermissionMode("")
+
+	if mgr.dangerouslyBypassSandbox {
+		t.Fatal("expected dangerouslyBypassSandbox to stay disabled")
+	}
+	if mgr.sandbox != defaultSandbox {
+		t.Fatalf("expected sandbox %q, got %q", defaultSandbox, mgr.sandbox)
+	}
+}
+
+func TestConfigurePermissionModeSandbox(t *testing.T) {
+	mgr := NewManager("/tmp/projects", "")
+	mgr.ConfigurePermissionMode("read-only")
+
+	if mgr.dangerouslyBypassSandbox {
+		t.Fatal("expected dangerouslyBypassSandbox to be disabled")
+	}
+	if mgr.sandbox != "read-only" {
+		t.Fatalf("expected sandbox %q, got %q", "read-only", mgr.sandbox)
+	}
+}

--- a/internal/codexbot/bot.go
+++ b/internal/codexbot/bot.go
@@ -1,0 +1,669 @@
+package codexbot
+
+import (
+	"fmt"
+	"html"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/zevro-ai/remote-control-on-demand/internal/codex"
+	"github.com/zevro-ai/remote-control-on-demand/internal/session"
+	tele "gopkg.in/telebot.v4"
+)
+
+const folderPageSize = 8
+
+type Bot struct {
+	tb            *tele.Bot
+	sessionMgr    *session.Manager
+	codexMgr      *codex.Manager
+	allowedUserID int64
+}
+
+func New(token string, allowedUserID int64, sessionMgr *session.Manager, codexMgr *codex.Manager) (*Bot, error) {
+	tb, err := tele.NewBot(tele.Settings{
+		Token:  token,
+		Poller: &tele.LongPoller{Timeout: 10 * time.Second},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating telegram bot: %w", err)
+	}
+
+	b := &Bot{
+		tb:            tb,
+		sessionMgr:    sessionMgr,
+		codexMgr:      codexMgr,
+		allowedUserID: allowedUserID,
+	}
+	b.registerHandlers()
+	b.registerCommands()
+	return b, nil
+}
+
+func (b *Bot) Start() {
+	go b.forwardNotifications()
+	b.sendWelcome()
+	b.tb.Start()
+}
+
+func (b *Bot) Stop() {
+	b.tb.Stop()
+}
+
+func (b *Bot) SendMessage(msg string) {
+	recipient := &user{id: b.allowedUserID}
+	b.tb.Send(recipient, msg, tele.ModeHTML)
+}
+
+func (b *Bot) registerHandlers() {
+	b.tb.Handle("/start", b.auth(b.handleStart))
+	b.tb.Handle("/list", b.auth(b.handleList))
+	b.tb.Handle("/kill", b.auth(b.handleKill))
+	b.tb.Handle("/status", b.auth(b.handleStatus))
+	b.tb.Handle("/logs", b.auth(b.handleLogs))
+	b.tb.Handle("/restart", b.auth(b.handleRestart))
+	b.tb.Handle("/new", b.auth(b.handleNew))
+	b.tb.Handle("/folders", b.auth(b.handleFolders))
+	b.tb.Handle("/sessions", b.auth(b.handleSessions))
+	b.tb.Handle("/use", b.auth(b.handleUse))
+	b.tb.Handle("/close", b.auth(b.handleClose))
+	b.tb.Handle("/current", b.auth(b.handleCurrent))
+	b.tb.Handle("/help", b.auth(b.handleHelp))
+	b.tb.Handle(tele.OnText, b.auth(b.handleChat))
+	b.tb.Handle(tele.OnCallback, b.auth(b.handleCallback))
+}
+
+func (b *Bot) registerCommands() {
+	b.tb.SetCommands([]tele.Command{
+		{Text: "start", Description: "Start a Claude session"},
+		{Text: "list", Description: "List Claude sessions"},
+		{Text: "kill", Description: "Stop a Claude session"},
+		{Text: "status", Description: "Show Claude session details"},
+		{Text: "logs", Description: "Show Claude session logs"},
+		{Text: "restart", Description: "Restart a Claude session"},
+		{Text: "folders", Description: "Browse repos for Claude"},
+		{Text: "new", Description: "Create a Codex session"},
+		{Text: "sessions", Description: "List Codex sessions"},
+		{Text: "use", Description: "Switch active Codex session"},
+		{Text: "close", Description: "Close a Codex session"},
+		{Text: "current", Description: "Show active Codex session"},
+		{Text: "help", Description: "Show all commands"},
+	})
+}
+
+func (b *Bot) auth(next tele.HandlerFunc) tele.HandlerFunc {
+	return func(c tele.Context) error {
+		if c.Sender().ID != b.allowedUserID {
+			if c.Callback() != nil {
+				return c.Respond(&tele.CallbackResponse{Text: "Access denied."})
+			}
+			return c.Send("Access denied.")
+		}
+		return next(c)
+	}
+}
+
+func (b *Bot) sendWelcome() {
+	var sb strings.Builder
+	sb.WriteString("<b>RCOD + Codex bot is online</b>\n\n")
+	sb.WriteString("<b>Claude remote control</b>\n")
+	sb.WriteString("Use <code>/start</code>, <code>/list</code>, <code>/status</code>, <code>/logs</code>, <code>/restart</code>, <code>/kill</code>, or <code>/folders</code>.\n\n")
+	sb.WriteString("<b>Codex chat</b>\n")
+	sb.WriteString("Use <code>/new repo</code> to create a Codex session, then send plain text to chat with Codex in that repo.\n")
+	sb.WriteString("Use <code>/sessions</code>, <code>/use</code>, <code>/current</code>, and <code>/close</code> to manage Codex chats.\n")
+
+	folders := b.listGitFolders()
+	if len(folders) > 0 {
+		sb.WriteString(fmt.Sprintf("\n\nFound <b>%d</b> git repo(s) under <code>%s</code>.", len(folders), html.EscapeString(b.baseFolder())))
+	}
+	if active, ok := b.codexMgr.Active(); ok {
+		sb.WriteString(fmt.Sprintf("\nCurrent Codex session: <code>%s</code> in <code>%s</code>", html.EscapeString(active.ID), html.EscapeString(active.RelName)))
+	}
+	b.SendMessage(sb.String())
+}
+
+func (b *Bot) handleStart(c tele.Context) error {
+	folder := strings.TrimSpace(c.Message().Payload)
+	if folder == "" {
+		return b.sendClaudeFolderPicker(c, "start", 0, "<b>Select a project to start in Claude</b>")
+	}
+
+	resolved, matches := matchFolderQuery(b.listGitFolders(), folder)
+	switch {
+	case resolved != "":
+		return b.startSession(c, resolved)
+	case len(matches) == 0:
+		return c.Send(fmt.Sprintf("No project matched <code>%s</code>.", html.EscapeString(folder)), tele.ModeHTML)
+	default:
+		return c.Send(
+			fmt.Sprintf(
+				"Multiple projects matched <code>%s</code>:\n%s\n\nUse <code>/start exact-name</code> or browse with <code>/folders</code>.",
+				html.EscapeString(folder),
+				formatCodeList(matches, 8),
+			),
+			tele.ModeHTML,
+		)
+	}
+}
+
+func (b *Bot) handleHelp(c tele.Context) error {
+	msg := `<b>RCOD + Codex</b>
+
+<b>Claude remote control</b>
+<code>/start repo</code> start a Claude session
+<code>/list</code> list Claude sessions
+<code>/kill id</code> stop a Claude session
+<code>/status id</code> show Claude session details
+<code>/logs id</code> show Claude logs
+<code>/restart id</code> restart a Claude session
+<code>/folders</code> browse repos for Claude
+
+<b>Codex chat</b>
+<code>/new repo</code> create a Codex session
+<code>/sessions</code> list Codex sessions
+<code>/use id</code> switch active Codex session
+<code>/close id</code> close a Codex session
+<code>/current</code> show active Codex session
+
+After creating a Codex session, send a normal text message and it will go to Codex.`
+	return c.Send(msg, tele.ModeHTML)
+}
+
+func (b *Bot) handleNew(c tele.Context) error {
+	folder := strings.TrimSpace(c.Message().Payload)
+	if folder == "" {
+		return b.sendFolderPicker(c, 0, "<b>Select a repository for a new Codex session</b>")
+	}
+
+	resolved, matches := matchFolderQuery(b.listGitFolders(), folder)
+	switch {
+	case resolved != "":
+		return b.createSession(c, resolved)
+	case len(matches) == 0:
+		return c.Send(fmt.Sprintf("No project matched <code>%s</code>.", html.EscapeString(folder)), tele.ModeHTML)
+	default:
+		return c.Send(
+			fmt.Sprintf(
+				"Multiple projects matched <code>%s</code>:\n%s\n\nUse <code>/new exact-name</code> or run <code>/new</code> to browse.",
+				html.EscapeString(folder),
+				formatCodeList(matches, 8),
+			),
+			tele.ModeHTML,
+		)
+	}
+}
+
+func (b *Bot) handleFolders(c tele.Context) error {
+	return b.sendClaudeFolderPicker(c, "start", 0, "<b>Available projects</b>\nTap to start a Claude session.")
+}
+
+func (b *Bot) handleSessions(c tele.Context) error {
+	sessions := b.codexMgr.List()
+	if len(sessions) == 0 {
+		return c.Send("No Codex sessions yet. Use /new.")
+	}
+
+	active, _ := b.codexMgr.Active()
+	var sb strings.Builder
+	sb.WriteString("<b>Codex sessions</b>\n")
+	for _, sess := range sessions {
+		marker := " "
+		if active != nil && active.ID == sess.ID {
+			marker = "*"
+		}
+		thread := "new"
+		if sess.ThreadID != "" {
+			thread = "live"
+		}
+		sb.WriteString(fmt.Sprintf(
+			"%s <code>%s</code> | <code>%s</code> | %s\n",
+			marker,
+			html.EscapeString(sess.ID),
+			html.EscapeString(sess.RelName),
+			thread,
+		))
+	}
+
+	return c.Send(sb.String(), b.sessionPickerMarkup(sessions), tele.ModeHTML)
+}
+
+func (b *Bot) handleUse(c tele.Context) error {
+	id := strings.TrimSpace(c.Message().Payload)
+	if id == "" {
+		return b.sendSessionPicker(c, "cuse", "<b>Select the active session</b>")
+	}
+
+	sess, err := b.codexMgr.SetActive(id)
+	if err != nil {
+		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
+	}
+
+	return c.Send(
+		fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)),
+		b.sessionActions(sess),
+		tele.ModeHTML,
+	)
+}
+
+func (b *Bot) handleClose(c tele.Context) error {
+	id := strings.TrimSpace(c.Message().Payload)
+	if id == "" {
+		return b.sendSessionPicker(c, "cclose", "<b>Select a session to close</b>")
+	}
+
+	if err := b.codexMgr.Close(id); err != nil {
+		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
+	}
+	return c.Send(fmt.Sprintf("Closed session <code>%s</code>.", html.EscapeString(id)), tele.ModeHTML)
+}
+
+func (b *Bot) handleCurrent(c tele.Context) error {
+	sess, ok := b.codexMgr.Active()
+	if !ok {
+		return c.Send("No active session. Use /new or /use.")
+	}
+
+	thread := "not started"
+	if sess.ThreadID != "" {
+		thread = sess.ThreadID
+	}
+	msg := fmt.Sprintf(
+		"<b>Active session</b>\nID: <code>%s</code>\nProject: <code>%s</code>\nThread: <code>%s</code>",
+		html.EscapeString(sess.ID),
+		html.EscapeString(sess.RelName),
+		html.EscapeString(thread),
+	)
+	return c.Send(msg, b.sessionActions(sess), tele.ModeHTML)
+}
+
+func (b *Bot) handleChat(c tele.Context) error {
+	msg := c.Message()
+	if msg == nil {
+		return nil
+	}
+	if strings.HasPrefix(strings.TrimSpace(msg.Text), "/") {
+		return nil
+	}
+
+	sess, err := b.codexMgr.ResolveActive()
+	if err != nil {
+		return c.Send(err.Error())
+	}
+
+	_ = c.Notify(tele.Typing)
+	replySession, response, err := b.codexMgr.Send(sess.ID, msg.Text)
+	if err != nil {
+		return c.Send(err.Error())
+	}
+
+	header := fmt.Sprintf("[%s | %s]\n", replySession.ID, replySession.RelName)
+	return b.sendTextChunks(c, header+response)
+}
+
+func (b *Bot) handleCallback(c tele.Context) error {
+	data := c.Callback().Data
+	_ = c.Respond()
+
+	parts := strings.Split(data, ":")
+	if len(parts) < 2 {
+		return nil
+	}
+
+	switch parts[0] {
+	case "pick":
+		if len(parts) != 3 {
+			return nil
+		}
+		index, err := strconv.Atoi(parts[2])
+		if err != nil {
+			return nil
+		}
+		return b.handleClaudeFolderPick(c, parts[1], index)
+	case "nav":
+		if len(parts) != 3 {
+			return nil
+		}
+		page, err := strconv.Atoi(parts[2])
+		if err != nil {
+			return nil
+		}
+		return b.sendClaudeFolderPicker(c, parts[1], page, "<b>Available projects</b>\nTap to start a Claude session.")
+	case "cpick":
+		if len(parts) != 2 {
+			return nil
+		}
+		index, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return nil
+		}
+		return b.handleFolderPick(c, index)
+	case "cnav":
+		if len(parts) != 2 {
+			return nil
+		}
+		page, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return nil
+		}
+		return b.sendFolderPicker(c, page, "<b>Available repositories</b>\nTap to create a Codex session.")
+	case "cuse":
+		if len(parts) != 2 {
+			return nil
+		}
+		sess, err := b.codexMgr.SetActive(parts[1])
+		if err != nil {
+			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
+		}
+		return c.Send(fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)), b.sessionActions(sess), tele.ModeHTML)
+	case "cclose":
+		if len(parts) != 2 {
+			return nil
+		}
+		if err := b.codexMgr.Close(parts[1]); err != nil {
+			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
+		}
+		return c.Send(fmt.Sprintf("Closed session <code>%s</code>.", html.EscapeString(parts[1])), tele.ModeHTML)
+	case "start", "kill", "status", "logs", "restart":
+		if len(parts) != 2 {
+			return nil
+		}
+		switch parts[0] {
+		case "start":
+			return b.startSession(c, parts[1])
+		case "kill":
+			return b.killSession(c, parts[1])
+		case "status":
+			return b.showStatus(c, parts[1])
+		case "logs":
+			return b.showLogs(c, parts[1])
+		case "restart":
+			return b.restartSession(c, parts[1])
+		}
+	}
+
+	return nil
+}
+
+func (b *Bot) createSession(c tele.Context, folder string) error {
+	sess, err := b.codexMgr.Create(folder)
+	if err != nil {
+		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
+	}
+
+	msg := fmt.Sprintf(
+		"<b>Codex session created</b>\nID: <code>%s</code>\nProject: <code>%s</code>\n\nSend a normal text message now and I will forward it to Codex.",
+		html.EscapeString(sess.ID),
+		html.EscapeString(sess.RelName),
+	)
+	return c.Send(msg, b.sessionActions(sess), tele.ModeHTML)
+}
+
+func (b *Bot) sendFolderPicker(c tele.Context, page int, text string) error {
+	folders := b.listGitFolders()
+	if len(folders) == 0 {
+		return c.Send("No git repositories found in the projects folder.")
+	}
+
+	if page < 0 {
+		page = 0
+	}
+	lastPage := (len(folders) - 1) / folderPageSize
+	if page > lastPage {
+		page = lastPage
+	}
+
+	start := page * folderPageSize
+	end := min(start+folderPageSize, len(folders))
+
+	markup := &tele.ReplyMarkup{}
+	var rows [][]tele.InlineButton
+	for i, folder := range folders[start:end] {
+		rows = append(rows, []tele.InlineButton{{
+			Text: "Repo " + folder,
+			Data: fmt.Sprintf("cpick:%d", start+i),
+		}})
+	}
+
+	if lastPage > 0 {
+		var navRow []tele.InlineButton
+		if page > 0 {
+			navRow = append(navRow, tele.InlineButton{Text: "Prev", Data: fmt.Sprintf("cnav:%d", page-1)})
+		}
+		navRow = append(navRow, tele.InlineButton{Text: fmt.Sprintf("%d/%d", page+1, lastPage+1), Data: "noop:0"})
+		if page < lastPage {
+			navRow = append(navRow, tele.InlineButton{Text: "Next", Data: fmt.Sprintf("cnav:%d", page+1)})
+		}
+		rows = append(rows, navRow)
+	}
+
+	markup.InlineKeyboard = rows
+	return c.Send(text, markup, tele.ModeHTML)
+}
+
+func (b *Bot) sendSessionPicker(c tele.Context, action, text string) error {
+	sessions := b.codexMgr.List()
+	if len(sessions) == 0 {
+		return c.Send("No Codex sessions yet. Use /new.")
+	}
+
+	markup := &tele.ReplyMarkup{}
+	var rows [][]tele.InlineButton
+	for _, sess := range sessions {
+		rows = append(rows, []tele.InlineButton{{
+			Text: fmt.Sprintf("%s - %s", sess.ID, sess.RelName),
+			Data: action + ":" + sess.ID,
+		}})
+	}
+	markup.InlineKeyboard = rows
+	return c.Send(text, markup, tele.ModeHTML)
+}
+
+func (b *Bot) handleFolderPick(c tele.Context, index int) error {
+	folders := b.listGitFolders()
+	if index < 0 || index >= len(folders) {
+		return c.Send("That repository is no longer available. Refresh with /new.")
+	}
+	return b.createSession(c, folders[index])
+}
+
+func (b *Bot) sessionActions(sess *codex.Session) *tele.ReplyMarkup {
+	markup := &tele.ReplyMarkup{}
+	markup.InlineKeyboard = [][]tele.InlineButton{
+		{
+			{Text: "Use", Data: "cuse:" + sess.ID},
+			{Text: "Close", Data: "cclose:" + sess.ID},
+		},
+	}
+	return markup
+}
+
+func (b *Bot) sessionPickerMarkup(sessions []*codex.Session) *tele.ReplyMarkup {
+	markup := &tele.ReplyMarkup{}
+	var rows [][]tele.InlineButton
+	for _, sess := range sessions {
+		rows = append(rows, []tele.InlineButton{
+			{Text: "Use " + sess.ID, Data: "cuse:" + sess.ID},
+			{Text: "Close", Data: "cclose:" + sess.ID},
+		})
+	}
+	markup.InlineKeyboard = rows
+	return markup
+}
+
+func (b *Bot) sendTextChunks(c tele.Context, text string) error {
+	const maxLen = 3500
+	if strings.TrimSpace(text) == "" {
+		return c.Send("(empty response)")
+	}
+
+	chunks := splitChunks(text, maxLen)
+	for _, chunk := range chunks {
+		if err := c.Send(chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func splitChunks(text string, maxLen int) []string {
+	runes := []rune(text)
+	if len(runes) <= maxLen {
+		return []string{text}
+	}
+
+	var chunks []string
+	for len(runes) > 0 {
+		if len(runes) <= maxLen {
+			chunks = append(chunks, string(runes))
+			break
+		}
+
+		cut := maxLen
+		for i := maxLen - 1; i >= maxLen/2; i-- {
+			if runes[i] == '\n' || runes[i] == ' ' {
+				cut = i + 1
+				break
+			}
+		}
+
+		chunks = append(chunks, string(runes[:cut]))
+		runes = runes[cut:]
+	}
+
+	return chunks
+}
+
+func (b *Bot) listGitFolders() []string {
+	return listGitFolders(b.baseFolder())
+}
+
+func (b *Bot) baseFolder() string {
+	if b.codexMgr != nil {
+		return b.codexMgr.BaseFolder()
+	}
+	if b.sessionMgr != nil {
+		return b.sessionMgr.BaseFolder()
+	}
+	return ""
+}
+
+func listGitFolders(baseFolder string) []string {
+	info, err := os.Stat(baseFolder)
+	if err != nil || !info.IsDir() {
+		return nil
+	}
+
+	var folders []string
+	err = filepath.WalkDir(baseFolder, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if path == baseFolder {
+			return nil
+		}
+
+		if d.IsDir() {
+			if shouldSkipScanDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			if hasGitMetadata(path) {
+				rel, err := filepath.Rel(baseFolder, path)
+				if err == nil && rel != "." {
+					folders = append(folders, rel)
+				}
+				return filepath.SkipDir
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil
+	}
+
+	sort.Strings(folders)
+	return folders
+}
+
+func shouldSkipScanDir(name string) bool {
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+
+	switch name {
+	case "node_modules", "vendor", "dist", "build", "tmp":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasGitMetadata(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, ".git"))
+	return err == nil
+}
+
+func matchFolderQuery(folders []string, query string) (string, []string) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return "", nil
+	}
+
+	normalizedQuery := normalizeFolderQuery(query)
+	for _, folder := range folders {
+		if normalizeFolderQuery(folder) == normalizedQuery {
+			return folder, nil
+		}
+	}
+
+	var matches []string
+	for _, folder := range folders {
+		if strings.Contains(strings.ToLower(filepath.ToSlash(folder)), normalizedQuery) {
+			matches = append(matches, folder)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	return "", matches
+}
+
+func normalizeFolderQuery(value string) string {
+	return strings.ToLower(filepath.ToSlash(filepath.Clean(value)))
+}
+
+func formatCodeList(items []string, limit int) string {
+	if len(items) == 0 {
+		return ""
+	}
+
+	maxItems := min(len(items), limit)
+	lines := make([]string, 0, maxItems+1)
+	for _, item := range items[:maxItems] {
+		lines = append(lines, "• <code>"+html.EscapeString(item)+"</code>")
+	}
+	if len(items) > maxItems {
+		lines = append(lines, fmt.Sprintf("• and %d more", len(items)-maxItems))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+type user struct {
+	id int64
+}
+
+func (u *user) Recipient() string {
+	return fmt.Sprintf("%d", u.id)
+}

--- a/internal/codexbot/bot_test.go
+++ b/internal/codexbot/bot_test.go
@@ -1,0 +1,32 @@
+package codexbot
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitChunksPreservesOriginalText(t *testing.T) {
+	text := "Naglowek\n```go\nfunc main() {\n    println(\"żółw\")\n}\n```\n"
+
+	chunks := splitChunks(text, 18)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+
+	if got := strings.Join(chunks, ""); got != text {
+		t.Fatalf("splitChunks() changed content\n got: %q\nwant: %q", got, text)
+	}
+}
+
+func TestSplitChunksPreservesUTF8Runes(t *testing.T) {
+	text := strings.Repeat("zażółć gęślą jaźń ", 40)
+
+	chunks := splitChunks(text, 23)
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple chunks, got %d", len(chunks))
+	}
+
+	if got := strings.Join(chunks, ""); got != text {
+		t.Fatalf("splitChunks() changed UTF-8 content\n got: %q\nwant: %q", got, text)
+	}
+}

--- a/internal/codexbot/claude_handlers.go
+++ b/internal/codexbot/claude_handlers.go
@@ -1,0 +1,254 @@
+package codexbot
+
+import (
+	"fmt"
+	"html"
+	"strings"
+	"time"
+
+	"github.com/zevro-ai/remote-control-on-demand/internal/session"
+	tele "gopkg.in/telebot.v4"
+)
+
+func (b *Bot) forwardNotifications() {
+	if b.sessionMgr == nil {
+		return
+	}
+
+	for n := range b.sessionMgr.Notifications() {
+		b.SendMessage(n.Message)
+	}
+}
+
+func (b *Bot) handleList(c tele.Context) error {
+	sessions := b.sessionMgr.List()
+	if len(sessions) == 0 {
+		return c.Send("No active Claude sessions.")
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<b>Claude sessions</b>\n")
+	for _, s := range sessions {
+		uptime := time.Since(s.StartedAt).Truncate(time.Second)
+		sb.WriteString(fmt.Sprintf(
+			"<code>%s</code> | <code>%s</code> | %s | %s\n",
+			html.EscapeString(s.ID),
+			html.EscapeString(s.RelName),
+			html.EscapeString(string(s.Status)),
+			html.EscapeString(uptime.String()),
+		))
+	}
+	return c.Send(sb.String(), tele.ModeHTML)
+}
+
+func (b *Bot) handleKill(c tele.Context) error {
+	id := strings.TrimSpace(c.Message().Payload)
+	if id == "" {
+		return b.sendClaudeSessionPicker(c, "kill", "<b>Select a Claude session to stop</b>")
+	}
+	return b.killSession(c, id)
+}
+
+func (b *Bot) handleStatus(c tele.Context) error {
+	id := strings.TrimSpace(c.Message().Payload)
+	if id == "" {
+		return b.sendClaudeSessionPicker(c, "status", "<b>Select a Claude session</b>")
+	}
+	return b.showStatus(c, id)
+}
+
+func (b *Bot) handleLogs(c tele.Context) error {
+	id := strings.TrimSpace(c.Message().Payload)
+	if id == "" {
+		return b.sendClaudeSessionPicker(c, "logs", "<b>Select a Claude session</b>")
+	}
+	return b.showLogs(c, id)
+}
+
+func (b *Bot) handleRestart(c tele.Context) error {
+	id := strings.TrimSpace(c.Message().Payload)
+	if id == "" {
+		return b.sendClaudeSessionPicker(c, "restart", "<b>Select a Claude session to restart</b>")
+	}
+	return b.restartSession(c, id)
+}
+
+func (b *Bot) startSession(c tele.Context, folder string) error {
+	sess, err := b.sessionMgr.Start(folder)
+	if err != nil {
+		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
+	}
+
+	msg := fmt.Sprintf(
+		"<b>Claude session started</b>\nID: <code>%s</code>\nProject: <code>%s</code>",
+		html.EscapeString(sess.ID),
+		html.EscapeString(folder),
+	)
+	return c.Send(msg, b.claudeSessionActions(sess), tele.ModeHTML)
+}
+
+func (b *Bot) killSession(c tele.Context, id string) error {
+	if err := b.sessionMgr.Kill(id); err != nil {
+		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
+	}
+	return c.Send(fmt.Sprintf("Claude session <code>%s</code> stopped.", html.EscapeString(id)), tele.ModeHTML)
+}
+
+func (b *Bot) showStatus(c tele.Context, id string) error {
+	sess, ok := b.sessionMgr.Get(id)
+	if !ok {
+		return c.Send(fmt.Sprintf("Claude session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
+	}
+
+	uptime := time.Since(sess.StartedAt).Truncate(time.Second)
+	pid := 0
+	if sess.Cmd != nil && sess.Cmd.Process != nil {
+		pid = sess.Cmd.Process.Pid
+	}
+
+	msg := fmt.Sprintf(
+		"<b>Claude session %s</b>\nProject: <code>%s</code>\nFolder: <code>%s</code>\nStatus: %s\nPID: %d\nUptime: %s\nRestarts: %d",
+		html.EscapeString(sess.ID),
+		html.EscapeString(sess.RelName),
+		html.EscapeString(sess.Folder),
+		html.EscapeString(string(sess.Status)),
+		pid,
+		html.EscapeString(uptime.String()),
+		sess.Restarts,
+	)
+	if sess.ClaudeURL != "" {
+		msg += fmt.Sprintf("\nClaude: <a href=\"%s\">open session</a>", html.EscapeString(sess.ClaudeURL))
+	}
+
+	return c.Send(msg, b.claudeSessionActions(sess), tele.ModeHTML)
+}
+
+func (b *Bot) showLogs(c tele.Context, id string) error {
+	sess, ok := b.sessionMgr.Get(id)
+	if !ok {
+		return c.Send(fmt.Sprintf("Claude session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
+	}
+
+	lines := sess.OutputBuf.Lines(50)
+	if len(lines) == 0 {
+		return c.Send("No logs available.")
+	}
+
+	output := strings.Join(lines, "\n")
+	if len(output) > 4000 {
+		output = output[len(output)-4000:]
+	}
+	return c.Send(fmt.Sprintf("<pre>%s</pre>", html.EscapeString(output)), tele.ModeHTML)
+}
+
+func (b *Bot) restartSession(c tele.Context, id string) error {
+	if err := b.sessionMgr.Restart(id); err != nil {
+		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
+	}
+
+	sess, ok := b.sessionMgr.Get(id)
+	if !ok {
+		return c.Send(fmt.Sprintf("Claude session <code>%s</code> restarted.", html.EscapeString(id)), tele.ModeHTML)
+	}
+	return c.Send(fmt.Sprintf("Claude session <code>%s</code> restarted.", html.EscapeString(id)), b.claudeSessionActions(sess), tele.ModeHTML)
+}
+
+func (b *Bot) sendClaudeFolderPicker(c tele.Context, action string, page int, text string) error {
+	folders := b.listGitFolders()
+	if len(folders) == 0 {
+		return c.Send("No git repositories found in the projects folder.", tele.ModeHTML)
+	}
+
+	if page < 0 {
+		page = 0
+	}
+	lastPage := (len(folders) - 1) / folderPageSize
+	if page > lastPage {
+		page = lastPage
+	}
+
+	start := page * folderPageSize
+	end := min(start+folderPageSize, len(folders))
+
+	markup := &tele.ReplyMarkup{}
+	var rows [][]tele.InlineButton
+	for i, folder := range folders[start:end] {
+		rows = append(rows, []tele.InlineButton{{
+			Text: "📂 " + folder,
+			Data: fmt.Sprintf("pick:%s:%d", action, start+i),
+		}})
+	}
+
+	if lastPage > 0 {
+		var navRow []tele.InlineButton
+		if page > 0 {
+			navRow = append(navRow, tele.InlineButton{Text: "◀ Prev", Data: fmt.Sprintf("nav:%s:%d", action, page-1)})
+		}
+		navRow = append(navRow, tele.InlineButton{Text: fmt.Sprintf("%d/%d", page+1, lastPage+1), Data: "noop:0"})
+		if page < lastPage {
+			navRow = append(navRow, tele.InlineButton{Text: "Next ▶", Data: fmt.Sprintf("nav:%s:%d", action, page+1)})
+		}
+		rows = append(rows, navRow)
+	}
+
+	markup.InlineKeyboard = rows
+	return c.Send(text, markup, tele.ModeHTML)
+}
+
+func (b *Bot) sendClaudeSessionPicker(c tele.Context, action, text string) error {
+	sessions := b.sessionMgr.List()
+	var running []*session.Session
+	for _, s := range sessions {
+		if s.Status == session.StatusRunning {
+			running = append(running, s)
+		}
+	}
+	if len(running) == 0 {
+		return c.Send("No active Claude sessions.")
+	}
+
+	markup := &tele.ReplyMarkup{}
+	var rows [][]tele.InlineButton
+	for _, s := range running {
+		label := fmt.Sprintf("%s - %s", s.ID, s.RelName)
+		rows = append(rows, []tele.InlineButton{{
+			Text: label,
+			Data: action + ":" + s.ID,
+		}})
+	}
+	markup.InlineKeyboard = rows
+	return c.Send(text, markup, tele.ModeHTML)
+}
+
+func (b *Bot) handleClaudeFolderPick(c tele.Context, action string, index int) error {
+	folders := b.listGitFolders()
+	if index < 0 || index >= len(folders) {
+		return c.Send("That project is no longer available. Refresh with <code>/folders</code>.", tele.ModeHTML)
+	}
+
+	switch action {
+	case "start":
+		return b.startSession(c, folders[index])
+	default:
+		return nil
+	}
+}
+
+func (b *Bot) claudeSessionActions(sess *session.Session) *tele.ReplyMarkup {
+	markup := &tele.ReplyMarkup{}
+	rows := [][]tele.InlineButton{
+		{
+			{Text: "Status", Data: "status:" + sess.ID},
+			{Text: "Logs", Data: "logs:" + sess.ID},
+		},
+		{
+			{Text: "Restart", Data: "restart:" + sess.ID},
+			{Text: "Stop", Data: "kill:" + sess.ID},
+		},
+	}
+	if sess.ClaudeURL != "" {
+		rows = append(rows, []tele.InlineButton{{Text: "Open Claude", URL: sess.ClaudeURL}})
+	}
+	markup.InlineKeyboard = rows
+	return markup
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -22,11 +23,20 @@ type TelegramConfig struct {
 
 type RCConfig struct {
 	BaseFolder          string               `yaml:"base_folder"`
+	PermissionMode      string               `yaml:"permission_mode,omitempty"`
 	AutoRestart         bool                 `yaml:"auto_restart"`
 	MaxRestarts         int                  `yaml:"max_restarts"`
 	RestartDelaySeconds int                  `yaml:"restart_delay_seconds"`
 	Notifications       *NotificationsConfig `yaml:"notifications,omitempty"`
 }
+
+const (
+	DefaultCodexPermissionMode = "workspace-write"
+	PermissionModeBypass       = "bypassPermissions"
+	PermissionModeReadOnly     = "read-only"
+	PermissionModeWorkspace    = "workspace-write"
+	PermissionModeDangerFull   = "danger-full-access"
+)
 
 // ProjectConfig represents per-project settings in .rcod.yaml
 type ProjectConfig struct {
@@ -128,6 +138,9 @@ func (c *Config) Validate() error {
 	if c.RC.RestartDelaySeconds < 0 {
 		return fmt.Errorf("rc.restart_delay_seconds must be >= 0")
 	}
+	if err := ValidateCodexPermissionMode(c.RC.PermissionMode); err != nil {
+		return fmt.Errorf("rc.permission_mode: %w", err)
+	}
 
 	if c.RC.Notifications != nil {
 		if err := c.RC.Notifications.Validate(); err != nil {
@@ -136,6 +149,23 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+func NormalizeCodexPermissionMode(permissionMode string) string {
+	permissionMode = strings.TrimSpace(permissionMode)
+	if permissionMode == "" {
+		return DefaultCodexPermissionMode
+	}
+	return permissionMode
+}
+
+func ValidateCodexPermissionMode(permissionMode string) error {
+	switch NormalizeCodexPermissionMode(permissionMode) {
+	case PermissionModeBypass, PermissionModeReadOnly, PermissionModeWorkspace, PermissionModeDangerFull:
+		return nil
+	default:
+		return fmt.Errorf("must be one of %q, %q, %q, or %q", PermissionModeBypass, PermissionModeReadOnly, PermissionModeWorkspace, PermissionModeDangerFull)
+	}
 }
 
 func (c *Config) Save(path string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -231,4 +232,62 @@ func TestRedactToken(t *testing.T) {
 			t.Fatalf("expected redacted token, got %q", got)
 		}
 	})
+}
+
+func TestValidateCodexPermissionMode(t *testing.T) {
+	validModes := []string{
+		"",
+		PermissionModeBypass,
+		PermissionModeReadOnly,
+		PermissionModeWorkspace,
+		PermissionModeDangerFull,
+	}
+
+	for _, mode := range validModes {
+		t.Run("valid "+NormalizeCodexPermissionMode(mode), func(t *testing.T) {
+			if err := ValidateCodexPermissionMode(mode); err != nil {
+				t.Fatalf("expected mode %q to be valid, got %v", mode, err)
+			}
+		})
+	}
+
+	t.Run("invalid mode", func(t *testing.T) {
+		err := ValidateCodexPermissionMode("plan")
+		if err == nil {
+			t.Fatal("expected invalid mode error")
+		}
+		if !strings.Contains(err.Error(), PermissionModeWorkspace) {
+			t.Fatalf("expected allowed values in error, got %v", err)
+		}
+	})
+}
+
+func TestConfigValidatePermissionMode(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "rcod-config-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cfg := &Config{
+		Telegram: TelegramConfig{
+			Token:         "token",
+			AllowedUserID: 123,
+		},
+		RC: RCConfig{
+			BaseFolder:          tmpDir,
+			PermissionMode:      "plan",
+			AutoRestart:         true,
+			MaxRestarts:         3,
+			RestartDelaySeconds: 5,
+		},
+	}
+
+	err = cfg.Validate()
+	if err == nil {
+		t.Fatal("expected invalid permission mode error")
+	}
+	if !strings.Contains(err.Error(), "rc.permission_mode") {
+		t.Fatalf("expected rc.permission_mode error, got %v", err)
+	}
 }

--- a/internal/config/onboarding.go
+++ b/internal/config/onboarding.go
@@ -295,6 +295,7 @@ func RunOnboarding(configPath string) (*Config, error) {
 		},
 		RC: RCConfig{
 			BaseFolder:          baseFolder,
+			PermissionMode:      DefaultCodexPermissionMode,
 			AutoRestart:         autoRestart,
 			MaxRestarts:         maxRestarts,
 			RestartDelaySeconds: restartDelay,
@@ -309,6 +310,7 @@ func RunOnboarding(configPath string) (*Config, error) {
 	fmt.Printf("    %s  %s\n", summaryLabel("Token          "), tokenPreview)
 	fmt.Printf("    %s  %d\n", summaryLabel("User ID        "), userID)
 	fmt.Printf("    %s  %s\n", summaryLabel("Projects folder"), baseFolder)
+	fmt.Printf("    %s  %s\n", summaryLabel("Codex access   "), cfg.RC.PermissionMode)
 	if autoRestart {
 		fmt.Printf("    %s  enabled (%d max, %ds delay)\n", summaryLabel("Auto-restart   "), maxRestarts, restartDelay)
 	} else {

--- a/packaging/launchd/ai.zevro.codexbot.plist
+++ b/packaging/launchd/ai.zevro.codexbot.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.zevro.codexbot</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string><REPO_PATH>/codexbot</string>
+    <string>--config</string>
+    <string><CONFIG_PATH></string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string><REPO_PATH></string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string><LOG_PATH>/codexbot.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string><LOG_PATH>/codexbot.stderr.log</string>
+</dict>
+</plist>

--- a/scripts/install-codexbot-native-launchd.sh
+++ b/scripts/install-codexbot-native-launchd.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="$ROOT_DIR/.codexbot"
+LOG_DIR="$STATE_DIR/launchd"
+BIN_PATH="$ROOT_DIR/codexbot"
+CONFIG_PATH="${1:-$ROOT_DIR/config.yaml}"
+GO_BIN="${GO_BIN:-/usr/local/go/bin/go}"
+TEMPLATE_PATH="$ROOT_DIR/packaging/launchd/ai.zevro.codexbot.plist"
+LABEL="ai.zevro.codexbot"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+PLIST_PATH="$PLIST_DIR/$LABEL.plist"
+LAUNCHD_TARGET="gui/$UID/$LABEL"
+
+canonicalize_path() {
+  local input="$1"
+  local dir
+  dir="$(cd -- "$(dirname -- "$input")" && pwd -P)"
+  printf '%s/%s\n' "$dir" "$(basename -- "$input")"
+}
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed 's/[\/&]/\\&/g'
+}
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "config not found: $CONFIG_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TEMPLATE_PATH" ]]; then
+  echo "launchd template not found: $TEMPLATE_PATH" >&2
+  exit 1
+fi
+
+CONFIG_PATH="$(canonicalize_path "$CONFIG_PATH")"
+
+mkdir -p "$STATE_DIR" "$LOG_DIR" "$PLIST_DIR"
+
+echo "building codexbot..."
+env \
+  GOPROXY="${GOPROXY:-off}" \
+  GONOSUMDB="${GONOSUMDB:-*}" \
+  GOCACHE="${GOCACHE:-$ROOT_DIR/.gocache}" \
+  GOMODCACHE="${GOMODCACHE:-$HOME/go/pkg/mod}" \
+  GOTMPDIR="${GOTMPDIR:-$ROOT_DIR/.gotmp}" \
+  "$GO_BIN" build -o "$BIN_PATH" ./cmd/codexbot
+
+echo "writing launchd agent to $PLIST_PATH..."
+sed \
+  -e "s/<REPO_PATH>/$(escape_sed_replacement "$ROOT_DIR")/g" \
+  -e "s/<CONFIG_PATH>/$(escape_sed_replacement "$CONFIG_PATH")/g" \
+  -e "s/<LOG_PATH>/$(escape_sed_replacement "$LOG_DIR")/g" \
+  "$TEMPLATE_PATH" >"$PLIST_PATH"
+
+echo "reloading launchd agent..."
+launchctl bootout "$LAUNCHD_TARGET" >/dev/null 2>&1 || true
+
+if ! launchctl bootstrap "gui/$UID" "$PLIST_PATH"; then
+  echo "bootstrap failed, retrying once..."
+  sleep 1
+  launchctl bootstrap "gui/$UID" "$PLIST_PATH"
+fi
+
+launchctl enable "$LAUNCHD_TARGET" >/dev/null 2>&1 || true
+launchctl kickstart -k "$LAUNCHD_TARGET"
+
+echo "launchd agent installed"
+echo "label: $LABEL"
+echo "plist: $PLIST_PATH"
+echo "stdout log: $LOG_DIR/codexbot.stdout.log"
+echo "stderr log: $LOG_DIR/codexbot.stderr.log"

--- a/scripts/reset-codexbot-native.sh
+++ b/scripts/reset-codexbot-native.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="$ROOT_DIR/.codexbot"
+LOG_FILE="$STATE_DIR/codexbot.log"
+CONFIG_PATH="${1:-$ROOT_DIR/config.yaml}"
+ROTATE_LOG="${ROTATE_LOG:-1}"
+
+mkdir -p "$STATE_DIR"
+
+if [[ "${ROTATE_LOG}" == "1" && -f "$LOG_FILE" ]]; then
+  timestamp="$(date +%Y%m%d-%H%M%S)"
+  rotated_log="$STATE_DIR/codexbot.$timestamp.log"
+  mv "$LOG_FILE" "$rotated_log"
+  echo "rotated log to $rotated_log"
+fi
+
+echo "stopping codexbot if it is running..."
+"$ROOT_DIR/scripts/stop-codexbot-native.sh" || true
+
+echo "starting codexbot..."
+"$ROOT_DIR/scripts/start-codexbot-native.sh" "$CONFIG_PATH"
+
+echo
+"$ROOT_DIR/scripts/status-codexbot-native.sh"
+echo "tail logs with: tail -f $LOG_FILE"

--- a/scripts/run-codexbot-native.sh
+++ b/scripts/run-codexbot-native.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+"$ROOT_DIR/scripts/start-codexbot-native.sh" "${1:-$ROOT_DIR/config.yaml}"
+echo
+"$ROOT_DIR/scripts/status-codexbot-native.sh"
+echo "tail logs with: tail -f $ROOT_DIR/.codexbot/codexbot.log"

--- a/scripts/start-codexbot-native.sh
+++ b/scripts/start-codexbot-native.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="$ROOT_DIR/.codexbot"
+PID_FILE="$STATE_DIR/codexbot.pid"
+LOG_FILE="$STATE_DIR/codexbot.log"
+BIN_PATH="$ROOT_DIR/codexbot"
+CONFIG_PATH="${1:-$ROOT_DIR/config.yaml}"
+GO_BIN="${GO_BIN:-/usr/local/go/bin/go}"
+
+canonicalize_path() {
+  local input="$1"
+  local dir
+  dir="$(cd -- "$(dirname -- "$input")" && pwd -P)"
+  printf '%s/%s\n' "$dir" "$(basename -- "$input")"
+}
+
+find_existing_pids() {
+  local ps_output
+  ps_output="$(ps -wwaxo pid=,command= 2>/dev/null || true)"
+  if [[ -z "$ps_output" ]]; then
+    return 0
+  fi
+
+  awk -v target="$BIN_PATH -config $CONFIG_PATH" '
+    {
+      pid = $1
+      $1 = ""
+      sub(/^ +/, "", $0)
+      if ($0 == target) {
+        print pid
+      }
+    }
+  ' <<<"$ps_output"
+}
+
+stop_pid() {
+  local pid="$1"
+  local label="$2"
+
+  if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+
+  echo "stopping $label (pid $pid)..."
+  kill "$pid"
+  for _ in {1..10}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "$label did not exit after 10s; sending SIGKILL..."
+  kill -9 "$pid" 2>/dev/null || true
+  for _ in {1..5}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "failed to stop $label (pid $pid)" >&2
+  return 1
+}
+
+stop_existing_instances() {
+  local pidfile_pid=""
+  local found_running=false
+  local pid
+
+  if [[ -f "$PID_FILE" ]]; then
+    pidfile_pid="$(cat "$PID_FILE")"
+    if [[ -n "$pidfile_pid" ]]; then
+      stop_pid "$pidfile_pid" "pidfile codexbot" || return 1
+    fi
+    rm -f "$PID_FILE"
+  fi
+
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    if [[ -n "$pidfile_pid" && "$pid" == "$pidfile_pid" ]]; then
+      continue
+    fi
+    found_running=true
+    stop_pid "$pid" "existing codexbot for $CONFIG_PATH" || return 1
+  done < <(find_existing_pids)
+
+  if [[ "$found_running" == true ]]; then
+    echo "previous codexbot instances stopped"
+  fi
+}
+
+mkdir -p "$STATE_DIR"
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "config not found: $CONFIG_PATH" >&2
+  exit 1
+fi
+
+CONFIG_PATH="$(canonicalize_path "$CONFIG_PATH")"
+
+echo "building codexbot..."
+env \
+  GOPROXY="${GOPROXY:-off}" \
+  GONOSUMDB="${GONOSUMDB:-*}" \
+  GOCACHE="${GOCACHE:-$ROOT_DIR/.gocache}" \
+  GOMODCACHE="${GOMODCACHE:-$HOME/go/pkg/mod}" \
+  GOTMPDIR="${GOTMPDIR:-$ROOT_DIR/.gotmp}" \
+  "$GO_BIN" build -o "$BIN_PATH" ./cmd/codexbot
+
+stop_existing_instances
+
+echo "starting codexbot..."
+(
+  cd "$ROOT_DIR"
+  nohup "$BIN_PATH" -config "$CONFIG_PATH" >>"$LOG_FILE" 2>&1 &
+  echo "$!" >"$PID_FILE"
+)
+
+sleep 2
+
+STARTED_PID="$(cat "$PID_FILE")"
+if kill -0 "$STARTED_PID" 2>/dev/null; then
+  echo "codexbot started (pid $STARTED_PID)"
+  echo "log: $LOG_FILE"
+  exit 0
+fi
+
+echo "codexbot failed to stay up; see $LOG_FILE" >&2
+exit 1

--- a/scripts/status-codexbot-native.sh
+++ b/scripts/status-codexbot-native.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="$ROOT_DIR/.codexbot"
+PID_FILE="$STATE_DIR/codexbot.pid"
+LOG_FILE="$STATE_DIR/codexbot.log"
+
+if [[ ! -f "$PID_FILE" ]]; then
+  echo "codexbot is not running"
+  [[ -f "$LOG_FILE" ]] && echo "last log: $LOG_FILE"
+  exit 1
+fi
+
+PID="$(cat "$PID_FILE")"
+if [[ -n "$PID" ]] && kill -0 "$PID" 2>/dev/null; then
+  echo "codexbot is running (pid $PID)"
+  echo "log: $LOG_FILE"
+  exit 0
+fi
+
+echo "stale pid file found; codexbot is not running"
+echo "log: $LOG_FILE"
+exit 1

--- a/scripts/stop-codexbot-native.sh
+++ b/scripts/stop-codexbot-native.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_DIR="$ROOT_DIR/.codexbot"
+PID_FILE="$STATE_DIR/codexbot.pid"
+
+if [[ ! -f "$PID_FILE" ]]; then
+  echo "codexbot is not running"
+  exit 0
+fi
+
+PID="$(cat "$PID_FILE")"
+if [[ -n "$PID" ]] && kill -0 "$PID" 2>/dev/null; then
+  kill "$PID"
+  for _ in {1..10}; do
+    if ! kill -0 "$PID" 2>/dev/null; then
+      rm -f "$PID_FILE"
+      echo "codexbot stopped"
+      exit 0
+    fi
+    sleep 1
+  done
+
+  echo "codexbot did not exit after 10s; send SIGKILL manually if needed" >&2
+  exit 1
+fi
+
+rm -f "$PID_FILE"
+echo "stale pid file removed"


### PR DESCRIPTION
## Summary
- add a Telegram-driven Codex manager with persistent repo-bound chat sessions
- keep the existing Claude remote control commands in the same bot, instead of replacing them
- add native launchd/shell tooling for running and restarting the combined bot on macOS
- add config validation and docs for Codex permission modes

## Testing
- go test ./...
- verified the launchd agent starts and the Telegram bot command list includes both Claude and Codex commands
