### PR TITLE
feat: stream codex exec events through chat sessions

### DIFF
--- a/internal/codex/manager.go
+++ b/internal/codex/manager.go
@@ -719,25 +719,52 @@ type execItem struct {
 func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb StreamCallback) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	toolIndexes := make(map[string]int)
-	var toolCount int
+	toolEntries := make(map[string]*toolEntry)
+	var nextToolIndex int
+	var nextAnonymousTool int
+	var anonymousQueue []string
 	var agentMessages []string
 
-	ensureTool := func(item execItem) int {
-		if index, ok := toolIndexes[item.ID]; ok {
-			return index
+	resolveToolKey := func(eventType string, item execItem) string {
+		if strings.TrimSpace(item.ID) != "" {
+			return item.ID
 		}
 
-		index := toolCount
-		toolCount++
-		toolIndexes[item.ID] = index
+		if eventType == "item.completed" && len(anonymousQueue) > 0 {
+			key := anonymousQueue[0]
+			anonymousQueue = anonymousQueue[1:]
+			return key
+		}
+
+		key := fmt.Sprintf("anonymous-%d", nextAnonymousTool)
+		nextAnonymousTool++
+		if eventType == "item.started" {
+			anonymousQueue = append(anonymousQueue, key)
+		}
+		return key
+	}
+
+	ensureTool := func(eventType string, item execItem) *toolEntry {
+		key := resolveToolKey(eventType, item)
+		if entry, ok := toolEntries[key]; ok {
+			return entry
+		}
+
+		entry := &toolEntry{index: nextToolIndex}
+		nextToolIndex++
+		toolEntries[key] = entry
 		if cb.OnToolStart != nil {
-			cb.OnToolStart(index, item.ID, "Bash")
+			cb.OnToolStart(entry.index, item.ID, toolNameForExecItem(item))
 		}
-		if cb.OnToolDelta != nil && item.Command != "" {
-			cb.OnToolDelta(index, marshalToolInput(item.Command))
+		return entry
+	}
+
+	emitToolDelta := func(entry *toolEntry, item execItem) {
+		if entry == nil || entry.deltaSent || cb.OnToolDelta == nil || item.Command == "" {
+			return
 		}
-		return index
+		cb.OnToolDelta(entry.index, marshalToolInput(item.Command))
+		entry.deltaSent = true
 	}
 
 	for scanner.Scan() {
@@ -757,7 +784,8 @@ func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb S
 		switch event.Type {
 		case "item.started":
 			if event.Item.Type == "command_execution" {
-				ensureTool(event.Item)
+				entry := ensureTool(event.Type, event.Item)
+				emitToolDelta(entry, event.Item)
 			}
 		case "item.completed":
 			switch event.Item.Type {
@@ -776,12 +804,30 @@ func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb S
 					cb.OnTextDelta(delta)
 				}
 			case "command_execution":
-				index := ensureTool(event.Item)
+				entry := ensureTool(event.Type, event.Item)
+				emitToolDelta(entry, event.Item)
 				if cb.OnToolFinish != nil {
-					cb.OnToolFinish(index)
+					cb.OnToolFinish(entry.index)
 				}
 			}
 		}
+	}
+}
+
+type toolEntry struct {
+	index     int
+	deltaSent bool
+}
+
+func toolNameForExecItem(item execItem) string {
+	switch item.Type {
+	case "command_execution":
+		// Codex currently models shell invocations as command_execution items.
+		return "Bash"
+	case "":
+		return "tool"
+	default:
+		return item.Type
 	}
 }
 

--- a/internal/codex/manager_test.go
+++ b/internal/codex/manager_test.go
@@ -284,6 +284,98 @@ func TestParseExecOutputEmitsStreamingToolAndTextEvents(t *testing.T) {
 	}
 }
 
+func TestParseExecOutputBackfillsCommandDeltaFromCompletedEvent(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		`{"type":"thread.started","thread_id":"thread-123"}`,
+		`{"type":"item.started","item":{"id":"item_1","type":"command_execution","status":"in_progress"}}`,
+		`{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"pwd","status":"completed"}}`,
+	}, "\n"))
+
+	var raw strings.Builder
+	var result execResult
+	var events []chat.ToolCallEvent
+
+	parseExecOutput(input, &result, &raw, StreamCallback{
+		OnToolStart: func(index int, id, name string) {
+			events = append(events, chat.ToolCallEvent{Index: index, ID: id, Name: name})
+		},
+		OnToolDelta: func(index int, partialJSON string) {
+			events = append(events, chat.ToolCallEvent{Index: index, PartialJSON: partialJSON})
+		},
+		OnToolFinish: func(index int) {
+			events = append(events, chat.ToolCallEvent{Index: index})
+		},
+	})
+
+	if result.ThreadID != "thread-123" {
+		t.Fatalf("ThreadID = %q", result.ThreadID)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("events = %d, want 3", len(events))
+	}
+
+	if events[0].Index != 0 || events[0].ID != "item_1" || events[0].Name != "Bash" {
+		t.Fatalf("tool start = %#v", events[0])
+	}
+
+	if events[1].Index != 0 || events[1].PartialJSON != `{"command":"pwd"}` {
+		t.Fatalf("tool delta = %#v", events[1])
+	}
+
+	if events[2].Index != 0 {
+		t.Fatalf("tool finish = %#v", events[2])
+	}
+}
+
+func TestParseExecOutputHandlesAnonymousCommandExecutionItems(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		`{"type":"item.started","item":{"id":"","type":"command_execution","command":"ls","status":"in_progress"}}`,
+		`{"type":"item.completed","item":{"id":"","type":"command_execution","command":"ls","status":"completed"}}`,
+		`{"type":"item.started","item":{"id":"","type":"command_execution","command":"pwd","status":"in_progress"}}`,
+		`{"type":"item.completed","item":{"id":"","type":"command_execution","command":"pwd","status":"completed"}}`,
+	}, "\n"))
+
+	var raw strings.Builder
+	var result execResult
+	var events []chat.ToolCallEvent
+
+	parseExecOutput(input, &result, &raw, StreamCallback{
+		OnToolStart: func(index int, id, name string) {
+			events = append(events, chat.ToolCallEvent{Index: index, ID: id, Name: name})
+		},
+		OnToolDelta: func(index int, partialJSON string) {
+			events = append(events, chat.ToolCallEvent{Index: index, PartialJSON: partialJSON})
+		},
+		OnToolFinish: func(index int) {
+			events = append(events, chat.ToolCallEvent{Index: index})
+		},
+	})
+
+	if len(events) != 6 {
+		t.Fatalf("events = %d, want 6", len(events))
+	}
+
+	if events[0].Index != 0 || events[0].Name != "Bash" {
+		t.Fatalf("first anonymous start = %#v", events[0])
+	}
+	if events[1].PartialJSON != `{"command":"ls"}` {
+		t.Fatalf("first anonymous delta = %#v", events[1])
+	}
+	if events[2].Index != 0 {
+		t.Fatalf("first anonymous finish = %#v", events[2])
+	}
+	if events[3].Index != 1 || events[3].Name != "Bash" {
+		t.Fatalf("second anonymous start = %#v", events[3])
+	}
+	if events[4].PartialJSON != `{"command":"pwd"}` {
+		t.Fatalf("second anonymous delta = %#v", events[4])
+	}
+	if events[5].Index != 1 {
+		t.Fatalf("second anonymous finish = %#v", events[5])
+	}
+}
+
 func TestRunCommandEmitsUserAndAssistantEvents(t *testing.T) {
 	baseDir := t.TempDir()
 	repoDir := filepath.Join(baseDir, "demo")


### PR DESCRIPTION
## Summary
- stream Codex exec JSONL events through the existing chat event pipeline instead of waiting only for the final assistant reply
- translate `command_execution` items into live tool start/delta/finish events so the dashboard can show Codex activity while a turn is running
- accumulate intermediate Codex `agent_message` items into the streamed assistant output and final persisted response

Closes #23.

## Verification
- [x] `go test ./internal/codex`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build -o /tmp/rcod ./cmd/bot`

## Notes
- no config changes
- frontend contract already supported these websocket events, so no dashboard code changes were needed in this PR
