### PR TITLE
feat: show live todo progress during streaming

### DIFF
--- a/app/src/components/AgentActivityFeed.tsx
+++ b/app/src/components/AgentActivityFeed.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { Message, StreamBlock } from "../api/types";
 import { getAuthenticatedAssetURL } from "../api/client";
+import { isTodoToolBlock, isToolUseBlock } from "../lib/todoProgress";
 import { ToolCallBlock } from "./ToolCallBlock";
 
 interface Props {
@@ -11,15 +12,16 @@ interface Props {
 
 export function AgentActivityFeed({ messages, streamBlocks, busy }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const visibleStreamBlocks = streamBlocks.filter((block) => !(isToolUseBlock(block) && isTodoToolBlock(block)));
 
   useEffect(() => {
     const el = containerRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [messages.length, streamBlocks.length, streamBlocks]);
+  }, [messages.length, visibleStreamBlocks.length, visibleStreamBlocks]);
 
   return (
     <div ref={containerRef} className="activity-feed">
-      {messages.length === 0 && streamBlocks.length === 0 && (
+      {!busy && messages.length === 0 && visibleStreamBlocks.length === 0 && (
         <div className="stream-placeholder">No messages yet. Send the first prompt.</div>
       )}
 
@@ -39,6 +41,7 @@ export function AgentActivityFeed({ messages, streamBlocks, busy }: Props) {
             <>
               {msg.blocks?.map((block, j) =>
                 block.type === "tool_use" ? (
+                  isTodoToolBlock(block) ? null : (
                   <ToolCallBlock
                     key={`msg-${i}-tool-${j}`}
                     name={block.name}
@@ -46,6 +49,7 @@ export function AgentActivityFeed({ messages, streamBlocks, busy }: Props) {
                     inputJSON={block.inputJSON}
                     done={block.done}
                   />
+                  )
                 ) : null
               )}
               <AssistantText content={msg.content} />
@@ -54,15 +58,19 @@ export function AgentActivityFeed({ messages, streamBlocks, busy }: Props) {
         </div>
       ))}
 
-      {streamBlocks.map((block, i) => {
+      {visibleStreamBlocks.map((block, i) => {
         if (block.type === "text") {
           return (
             <div key={`stream-${i}`} className="text-stream-block">
               {block.content}
-              {busy && i === streamBlocks.length - 1 && <span className="cursor-blink" />}
+              {busy && i === visibleStreamBlocks.length - 1 && <span className="cursor-blink" />}
             </div>
           );
         }
+        if (!isToolUseBlock(block)) {
+          return null;
+        }
+
         return (
           <ToolCallBlock
             key={`tool-${block.index}`}
@@ -75,7 +83,7 @@ export function AgentActivityFeed({ messages, streamBlocks, busy }: Props) {
         );
       })}
 
-      {busy && streamBlocks.length === 0 && (
+      {busy && visibleStreamBlocks.length === 0 && (
         <div className="thinking-indicator">
           <span className="tool-spinner" />
           <span style={{ color: "var(--color-text-muted)", fontSize: "0.82rem", marginLeft: "8px" }}>

--- a/app/src/components/SessionPanel.tsx
+++ b/app/src/components/SessionPanel.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
 import type { ChatSession, DraftAttachment, StreamBlock } from "../api/types";
+import { extractTodoProgress } from "../lib/todoProgress";
 import { AgentBadge } from "./AgentBadge";
 import { AgentActivityFeed } from "./AgentActivityFeed";
 import { MessageInput } from "./MessageInput";
+import { TodoProgressPanel } from "./TodoProgressPanel";
 
 interface Props {
   type: string;
@@ -17,6 +19,7 @@ interface Props {
 export function SessionPanel(props: Props) {
   const { session, type, streamBlocks } = props;
   const messages = session.messages || [];
+  const todoProgress = useMemo(() => extractTodoProgress(streamBlocks), [streamBlocks]);
 
   const telemetry = useMemo(
     () => [
@@ -43,6 +46,11 @@ export function SessionPanel(props: Props) {
         </div>
 
         <div className="session-panel__header-actions">
+          {todoProgress && (
+            <div className="session-panel__summary-pill">
+              {todoProgress.completedCount}/{todoProgress.totalCount} items
+            </div>
+          )}
           <div className={`live-pill ${session.busy ? "is-live" : ""}`}>
             {session.busy ? "Streaming" : "Standby"}
           </div>
@@ -73,6 +81,8 @@ export function SessionPanel(props: Props) {
               </div>
             ))}
           </div>
+
+          {todoProgress && <TodoProgressPanel progress={todoProgress} />}
 
           <div className="wiretap">
             <div className="wiretap__header">Wire Tap</div>

--- a/app/src/components/TodoProgressPanel.test.tsx
+++ b/app/src/components/TodoProgressPanel.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { TodoProgressPanel } from "./TodoProgressPanel";
+
+afterEach(cleanup);
+
+describe("TodoProgressPanel", () => {
+  it("renders progress counts and highlights the active item", () => {
+    render(
+      <TodoProgressPanel
+        progress={{
+          completedCount: 2,
+          totalCount: 4,
+          items: [
+            { text: "Read config", completed: true, active: false },
+            { text: "Patch parser", completed: true, active: false },
+            { text: "Write tests", completed: false, active: true },
+            { text: "Update docs", completed: false, active: false },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByText("Todo Progress")).toBeTruthy();
+    expect(screen.getAllByText("2/4")).toHaveLength(1);
+    expect(screen.getByText("Write tests")).toBeTruthy();
+    expect(screen.getByText("Update docs")).toBeTruthy();
+    expect(screen.getByText("2/4 items completed")).toBeTruthy();
+  });
+});

--- a/app/src/components/TodoProgressPanel.tsx
+++ b/app/src/components/TodoProgressPanel.tsx
@@ -1,0 +1,35 @@
+import type { TodoProgressState } from "../lib/todoProgress";
+
+interface Props {
+  progress: TodoProgressState;
+}
+
+export function TodoProgressPanel({ progress }: Props) {
+  return (
+    <section className="todo-progress">
+      <div className="todo-progress__header">
+        <div>
+          <div className="session-window__title">Todo Progress</div>
+          <p>{progress.completedCount}/{progress.totalCount} items completed</p>
+        </div>
+        <div className="todo-progress__summary">
+          {progress.completedCount}/{progress.totalCount}
+        </div>
+      </div>
+
+      <div className="todo-progress__list">
+        {progress.items.map((item) => (
+          <div
+            key={item.text}
+            className={`todo-progress__item ${item.completed ? "is-done" : ""} ${item.active ? "is-active" : ""}`}
+          >
+            <span className="todo-progress__status" aria-hidden="true">
+              {item.completed ? "\u2713" : item.active ? "\u23F3" : "\u25CB"}
+            </span>
+            <span className="todo-progress__text">{item.text}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -909,6 +909,18 @@ button {
   gap: 8px;
 }
 
+.session-panel__summary-pill {
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(103, 232, 249, 0.28);
+  background: rgba(103, 232, 249, 0.1);
+  color: var(--color-accent-cyan);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 /* Live pill */
 .live-pill {
   border-radius: 20px;
@@ -1072,6 +1084,105 @@ button {
   font-weight: 600;
   font-family: var(--font-mono);
   color: var(--color-text-primary);
+}
+
+.todo-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 14px 12px 0;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(103, 232, 249, 0.14);
+  background:
+    linear-gradient(180deg, rgba(7, 14, 18, 0.96), rgba(8, 12, 16, 0.9));
+}
+
+.todo-progress__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.todo-progress__header .session-window__title {
+  padding: 0;
+  border: 0;
+}
+
+.todo-progress__header p {
+  margin: 4px 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.todo-progress__summary {
+  flex-shrink: 0;
+  min-width: 54px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(6, 22, 26, 0.92);
+  color: var(--color-accent-cyan);
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.todo-progress__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.todo-progress__item {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  padding: 9px 10px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: rgba(15, 20, 24, 0.76);
+}
+
+.todo-progress__item.is-active {
+  border-color: rgba(251, 191, 36, 0.28);
+  background: rgba(46, 38, 9, 0.44);
+}
+
+.todo-progress__item.is-done {
+  background: rgba(12, 26, 19, 0.72);
+}
+
+.todo-progress__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.todo-progress__item.is-active .todo-progress__status {
+  color: var(--color-accent-orange);
+}
+
+.todo-progress__item.is-done .todo-progress__status {
+  color: var(--color-accent-green);
+}
+
+.todo-progress__text {
+  min-width: 0;
+  color: var(--color-text-primary);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.todo-progress__item.is-done .todo-progress__text {
+  color: var(--color-text-secondary);
 }
 
 /* ========== WIRETAP ========== */

--- a/app/src/lib/sessionWall.test.ts
+++ b/app/src/lib/sessionWall.test.ts
@@ -64,6 +64,26 @@ describe("buildSessionPreview", () => {
     ]);
   });
 
+  it("skips todo progress blocks in the terminal preview", () => {
+    const streamBlocks: StreamBlock[] = [
+      {
+        type: "tool_use",
+        index: 0,
+        id: "todo-1",
+        name: "TodoWrite",
+        inputJSON: `{"todos":[{"text":"Inspect config","completed":true},{"text":"Write tests","completed":false}]}`,
+        done: false,
+      },
+      { type: "text", content: "streamed answer" },
+    ];
+
+    const preview = buildSessionPreview(createSession({ busy: true }), streamBlocks, 4);
+
+    expect(preview).toEqual([
+      { tone: "assistant", text: "streamed answer" },
+    ]);
+  });
+
   it("falls back to an empty terminal line when nothing happened yet", () => {
     expect(buildSessionPreview(createSession(), [], getPreviewLineCount("compact"))).toEqual([
       { tone: "system", text: "awaiting first prompt" },

--- a/app/src/lib/sessionWall.ts
+++ b/app/src/lib/sessionWall.ts
@@ -1,4 +1,5 @@
 import type { ChatSession, StreamBlock } from "../api/types";
+import { isTodoToolBlock, isToolUseBlock } from "./todoProgress";
 
 export type { ChatSession };
 export type OverviewDensity = "compact" | "comfortable" | "focus";
@@ -119,6 +120,9 @@ export function buildSessionPreview(
 
     for (const block of message.blocks || []) {
       if (block.type === "tool_use") {
+        if (isTodoToolBlock(block)) {
+          continue;
+        }
         pushPreview(preview, "tool", formatToolLine(block.name, block.done));
       }
     }
@@ -127,7 +131,10 @@ export function buildSessionPreview(
   }
 
   for (const block of streamBlocks) {
-    if (block.type === "tool_use") {
+    if (isToolUseBlock(block)) {
+      if (isTodoToolBlock(block)) {
+        continue;
+      }
       pushPreview(preview, "tool", formatToolLine(block.name, block.done));
       continue;
     }

--- a/app/src/lib/todoProgress.test.ts
+++ b/app/src/lib/todoProgress.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { StreamBlock } from "../api/types";
+import { extractTodoProgress, isTodoToolBlock } from "./todoProgress";
+
+describe("isTodoToolBlock", () => {
+  it("recognizes TodoWrite blocks", () => {
+    const block: StreamBlock = {
+      type: "tool_use",
+      index: 1,
+      id: "todo-1",
+      name: "TodoWrite",
+      inputJSON: `{"todos":[{"text":"Inspect","completed":true}]}`,
+      done: false,
+    };
+
+    expect(isTodoToolBlock(block)).toBe(true);
+  });
+});
+
+describe("extractTodoProgress", () => {
+  it("returns the latest todo list state and infers the active item", () => {
+    const blocks: StreamBlock[] = [
+      {
+        type: "tool_use",
+        index: 1,
+        id: "todo-1",
+        name: "TodoWrite",
+        inputJSON: `{"todos":[{"text":"Inspect config","completed":false}]}`,
+        done: true,
+      },
+      {
+        type: "tool_use",
+        index: 2,
+        id: "todo-2",
+        name: "TodoWrite",
+        inputJSON: `{"todos":[{"text":"Inspect config","completed":true},{"text":"Write tests","completed":false},{"text":"Update docs","completed":false}]}`,
+        done: false,
+      },
+    ];
+
+    expect(extractTodoProgress(blocks)).toEqual({
+      completedCount: 1,
+      totalCount: 3,
+      items: [
+        { text: "Inspect config", completed: true, active: false },
+        { text: "Write tests", completed: false, active: true },
+        { text: "Update docs", completed: false, active: false },
+      ],
+    });
+  });
+
+  it("supports raw todo_list payloads from Codex", () => {
+    const blocks: StreamBlock[] = [
+      {
+        type: "tool_use",
+        index: 7,
+        id: "todo-7",
+        name: "todo_list",
+        inputJSON: `{"items":[{"text":"Read config","completed":true},{"text":"Patch UI","completed":false}]}`,
+        done: false,
+      },
+    ];
+
+    expect(extractTodoProgress(blocks)).toEqual({
+      completedCount: 1,
+      totalCount: 2,
+      items: [
+        { text: "Read config", completed: true, active: false },
+        { text: "Patch UI", completed: false, active: true },
+      ],
+    });
+  });
+
+  it("returns null for invalid or empty todo payloads", () => {
+    const blocks: StreamBlock[] = [
+      {
+        type: "tool_use",
+        index: 1,
+        id: "todo-1",
+        name: "TodoWrite",
+        inputJSON: `{"todos":[]}`,
+        done: true,
+      },
+    ];
+
+    expect(extractTodoProgress(blocks)).toBeNull();
+  });
+});

--- a/app/src/lib/todoProgress.ts
+++ b/app/src/lib/todoProgress.ts
@@ -1,0 +1,85 @@
+import type { StreamBlock } from "../api/types";
+
+export interface TodoProgressItem {
+  text: string;
+  completed: boolean;
+  active: boolean;
+}
+
+export interface TodoProgressState {
+  items: TodoProgressItem[];
+  completedCount: number;
+  totalCount: number;
+}
+
+type TodoToolBlock = Extract<StreamBlock, { type: "tool_use" }>;
+
+interface TodoPayloadItem {
+  text: string;
+  completed: boolean;
+}
+
+export function isToolUseBlock(block: StreamBlock): block is TodoToolBlock {
+  return block.type === "tool_use";
+}
+
+export function isTodoToolBlock(block: StreamBlock) {
+  return isToolUseBlock(block) && (block.name === "TodoWrite" || block.name === "todo_list");
+}
+
+export function extractTodoProgress(blocks: StreamBlock[]): TodoProgressState | null {
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index];
+    if (!block || !isToolUseBlock(block) || !isTodoToolBlock(block)) {
+      continue;
+    }
+
+    const items = parseTodoItems(block.inputJSON);
+    if (items.length === 0) {
+      continue;
+    }
+
+    const activeIndex = items.findIndex((item) => !item.completed);
+    const normalized = items.map((item, itemIndex): TodoProgressItem => ({
+      text: item.text,
+      completed: item.completed,
+      active: activeIndex === itemIndex,
+    }));
+
+    return {
+      items: normalized,
+      completedCount: normalized.filter((item) => item.completed).length,
+      totalCount: normalized.length,
+    };
+  }
+
+  return null;
+}
+
+function parseTodoItems(inputJSON: string): TodoPayloadItem[] {
+  if (!inputJSON) {
+    return [];
+  }
+
+  try {
+    const payload = JSON.parse(inputJSON) as {
+      todos?: Array<{ text?: string; completed?: boolean }>;
+      items?: Array<{ text?: string; completed?: boolean }>;
+    };
+
+    const rawItems = Array.isArray(payload.todos)
+      ? payload.todos
+      : Array.isArray(payload.items)
+        ? payload.items
+        : [];
+
+    return rawItems
+      .map((item) => ({
+        text: typeof item?.text === "string" ? item.text.trim() : "",
+        completed: Boolean(item?.completed),
+      }))
+      .filter((item) => item.text.length > 0);
+  } catch {
+    return [];
+  }
+}

--- a/internal/codex/manager.go
+++ b/internal/codex/manager.go
@@ -714,6 +714,10 @@ type execItem struct {
 	Command          string `json:"command,omitempty"`
 	AggregatedOutput string `json:"aggregated_output,omitempty"`
 	Status           string `json:"status,omitempty"`
+	Items            []struct {
+		Text      string `json:"text,omitempty"`
+		Completed bool   `json:"completed,omitempty"`
+	} `json:"items,omitempty"`
 }
 
 func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb StreamCallback) {
@@ -760,10 +764,14 @@ func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb S
 	}
 
 	emitToolDelta := func(entry *toolEntry, item execItem) {
-		if entry == nil || entry.deltaSent || cb.OnToolDelta == nil || item.Command == "" {
+		if entry == nil || entry.deltaSent || cb.OnToolDelta == nil {
 			return
 		}
-		cb.OnToolDelta(entry.index, marshalToolInput(item.Command))
+		payload := marshalToolInput(item)
+		if payload == "" {
+			return
+		}
+		cb.OnToolDelta(entry.index, payload)
 		entry.deltaSent = true
 	}
 
@@ -783,7 +791,7 @@ func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb S
 
 		switch event.Type {
 		case "item.started":
-			if event.Item.Type == "command_execution" {
+			if isStreamingToolItem(event.Item) {
 				entry := ensureTool(event.Type, event.Item)
 				emitToolDelta(entry, event.Item)
 			}
@@ -809,6 +817,12 @@ func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb S
 				if cb.OnToolFinish != nil {
 					cb.OnToolFinish(entry.index)
 				}
+			case "todo_list":
+				entry := ensureTool(event.Type, event.Item)
+				emitToolDelta(entry, event.Item)
+				if cb.OnToolFinish != nil {
+					cb.OnToolFinish(entry.index)
+				}
 			}
 		}
 	}
@@ -824,6 +838,9 @@ func toolNameForExecItem(item execItem) string {
 	case "command_execution":
 		// Codex currently models shell invocations as command_execution items.
 		return "Bash"
+	case "todo_list":
+		// Normalize Codex todo_list items to the TodoWrite tool semantics used in the dashboard.
+		return "TodoWrite"
 	case "":
 		return "tool"
 	default:
@@ -831,12 +848,45 @@ func toolNameForExecItem(item execItem) string {
 	}
 }
 
-func marshalToolInput(command string) string {
-	data, err := json.Marshal(struct {
-		Command string `json:"command"`
-	}{
-		Command: command,
-	})
+func isStreamingToolItem(item execItem) bool {
+	switch item.Type {
+	case "command_execution", "todo_list":
+		return true
+	default:
+		return false
+	}
+}
+
+func marshalToolInput(item execItem) string {
+	var payload any
+
+	switch item.Type {
+	case "command_execution":
+		if item.Command == "" {
+			return ""
+		}
+		payload = struct {
+			Command string `json:"command"`
+		}{
+			Command: item.Command,
+		}
+	case "todo_list":
+		if len(item.Items) == 0 {
+			return ""
+		}
+		payload = struct {
+			Todos []struct {
+				Text      string `json:"text,omitempty"`
+				Completed bool   `json:"completed,omitempty"`
+			} `json:"todos"`
+		}{
+			Todos: item.Items,
+		}
+	default:
+		return ""
+	}
+
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return ""
 	}

--- a/internal/codex/manager_test.go
+++ b/internal/codex/manager_test.go
@@ -376,6 +376,45 @@ func TestParseExecOutputHandlesAnonymousCommandExecutionItems(t *testing.T) {
 	}
 }
 
+func TestParseExecOutputEmitsTodoListAsTodoWriteTool(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		`{"type":"item.started","item":{"id":"item_7","type":"todo_list","items":[{"text":"Inspect config","completed":true},{"text":"Write tests","completed":false}]}}`,
+		`{"type":"item.completed","item":{"id":"item_7","type":"todo_list","items":[{"text":"Inspect config","completed":true},{"text":"Write tests","completed":false}]}}`,
+	}, "\n"))
+
+	var raw strings.Builder
+	var result execResult
+	var events []chat.ToolCallEvent
+
+	parseExecOutput(input, &result, &raw, StreamCallback{
+		OnToolStart: func(index int, id, name string) {
+			events = append(events, chat.ToolCallEvent{Index: index, ID: id, Name: name})
+		},
+		OnToolDelta: func(index int, partialJSON string) {
+			events = append(events, chat.ToolCallEvent{Index: index, PartialJSON: partialJSON})
+		},
+		OnToolFinish: func(index int) {
+			events = append(events, chat.ToolCallEvent{Index: index})
+		},
+	})
+
+	if len(events) != 3 {
+		t.Fatalf("events = %d, want 3", len(events))
+	}
+
+	if events[0].Index != 0 || events[0].ID != "item_7" || events[0].Name != "TodoWrite" {
+		t.Fatalf("todo start = %#v", events[0])
+	}
+
+	if events[1].Index != 0 || events[1].PartialJSON != `{"todos":[{"text":"Inspect config","completed":true},{"text":"Write tests"}]}` {
+		t.Fatalf("todo delta = %#v", events[1])
+	}
+
+	if events[2].Index != 0 {
+		t.Fatalf("todo finish = %#v", events[2])
+	}
+}
+
 func TestRunCommandEmitsUserAndAssistantEvents(t *testing.T) {
 	baseDir := t.TempDir()
 	repoDir := filepath.Join(baseDir, "demo")


### PR DESCRIPTION
## Summary
- normalize Codex `todo_list` stream events into dashboard-consumable TodoWrite tool blocks
- derive live todo progress in the React dashboard and show a dedicated right-side progress panel during streaming
- hide raw todo tool blocks from the activity feed/preview while keeping compact progress counts visible in the session panel

## Testing
- go test ./internal/codex
- go test ./...
- go vet ./...
- go build -o /tmp/rcod ./cmd/bot
- npm test
- npm run build

Closes #24