### PR TITLE
fix: embed dashboard assets in release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,8 @@ builds:
   - id: rcod
     main: ./cmd/rcodbot
     binary: rcod
+    tags:
+      - release
     env:
       - CGO_ENABLED=0
     goos:

--- a/cmd/rcodbot/release_config_test.go
+++ b/cmd/rcodbot/release_config_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type goreleaserConfig struct {
+	Builds []goreleaserBuild `yaml:"builds"`
+}
+
+type goreleaserBuild struct {
+	ID   string   `yaml:"id"`
+	Tags []string `yaml:"tags"`
+}
+
+func TestGoReleaserBuildsRCODWithReleaseTag(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+
+	configPath := filepath.Join(filepath.Dir(currentFile), "..", "..", ".goreleaser.yml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", configPath, err)
+	}
+
+	var cfg goreleaserConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal(%q): %v", configPath, err)
+	}
+
+	for _, build := range cfg.Builds {
+		if build.ID != "rcod" {
+			continue
+		}
+
+		for _, tag := range build.Tags {
+			if tag == "release" {
+				return
+			}
+		}
+
+		t.Fatalf("rcod build must include release tag, got %v", build.Tags)
+	}
+
+	t.Fatal("rcod build not found in .goreleaser.yml")
+}


### PR DESCRIPTION
## Summary
- build the `rcod` release artifact with the `release` Go build tag
- keep embedding the dashboard SPA from `internal/httpapi/dashboard/dist` in release binaries and Debian packages
- add a regression test that fails if `.goreleaser.yml` stops setting the `release` tag for `rcod`

## Testing
- `go test ./...`
- `go build -tags release -o /tmp/rcod-release-check ./cmd/rcodbot`

Fixes #37