### PR TITLE
fix: prevent symlink path escapes

### DIFF
--- a/internal/chat/helpers.go
+++ b/internal/chat/helpers.go
@@ -90,6 +90,9 @@ func ResolveProjectPath(baseFolder, folder string) (string, string, error) {
 	if err != nil {
 		return "", "", fmt.Errorf("resolving folder %q: %w", folder, err)
 	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(os.PathSeparator)) {
+		return "", "", fmt.Errorf("folder %q must stay within rc.base_folder", folder)
+	}
 	relResolved, err := filepath.Rel(baseResolved, targetResolved)
 	if err != nil {
 		return "", "", fmt.Errorf("resolving folder %q: %w", folder, err)

--- a/internal/chat/helpers_test.go
+++ b/internal/chat/helpers_test.go
@@ -20,6 +20,25 @@ func TestResolveProjectPathRejectsSymlinkEscape(t *testing.T) {
 	}
 }
 
+func TestResolveProjectPathRejectsLexicalEscapeEvenIfSymlinkResolvesInsideBase(t *testing.T) {
+	baseDir := t.TempDir()
+	insideDir := filepath.Join(baseDir, "demo")
+	if err := os.MkdirAll(insideDir, 0755); err != nil {
+		t.Fatalf("MkdirAll(demo): %v", err)
+	}
+
+	aliasDir := t.TempDir()
+	linkPath := filepath.Join(aliasDir, "demo-link")
+	if err := os.Symlink(insideDir, linkPath); err != nil {
+		t.Skipf("Symlink() unsupported in this environment: %v", err)
+	}
+
+	folder := filepath.Join("..", filepath.Base(aliasDir), "demo-link")
+	if _, _, err := ResolveProjectPath(baseDir, folder); err == nil {
+		t.Fatal("expected lexical escape through sibling symlink path to be rejected")
+	}
+}
+
 func TestResolveProjectPathAllowsMissingChildWithinResolvedBase(t *testing.T) {
 	baseDir := t.TempDir()
 	realBase := filepath.Join(baseDir, "real")


### PR DESCRIPTION
## Summary
- make `ResolveProjectPath` validate containment against symlink-resolved paths
- keep relative display names stable while returning the resolved project path
- add regression coverage for symlink escape and missing children under a symlinked base

## Testing
- go test ./internal/chat
- go test ./...
- go vet ./...
- go build -o /tmp/rcod ./cmd/rcodbot

Follow-up hotfix for the review finding on #40.