### PR TITLE
feat: migrate Claude onto shared provider adapter

### DIFF
--- a/cmd/rcodbot/main.go
+++ b/cmd/rcodbot/main.go
@@ -146,20 +146,7 @@ func main() {
 			log.Fatalf("Registering runtime provider: %v", err)
 		}
 
-		claudeProvider, err := provider.NewChatAdapter(provider.Metadata{
-			ID:          "claude",
-			DisplayName: "Claude",
-			Chat: &provider.ChatCapabilities{
-				StreamingDeltas:  true,
-				ShellCommandExec: true,
-				ThreadResume:     true,
-				ImageAttachments: true,
-			},
-		}, claudeMgr)
-		if err != nil {
-			log.Fatalf("Creating Claude chat provider registry entry: %v", err)
-		}
-		if err := registry.RegisterChat(claudeProvider); err != nil {
+		if err := registry.RegisterChat(claudeMgr); err != nil {
 			log.Fatalf("Registering Claude chat provider: %v", err)
 		}
 

--- a/internal/claudechat/manager.go
+++ b/internal/claudechat/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zevro-ai/remote-control-on-demand/internal/bashcmd"
 	"github.com/zevro-ai/remote-control-on-demand/internal/chat"
 	"github.com/zevro-ai/remote-control-on-demand/internal/config"
+	"github.com/zevro-ai/remote-control-on-demand/internal/provider"
 )
 
 const (
@@ -79,8 +80,21 @@ func (m *Manager) Shutdown() {
 	m.core.Shutdown()
 }
 
+func (m *Manager) Metadata() provider.Metadata {
+	return provider.Metadata{
+		ID:          "claude",
+		DisplayName: "Claude",
+		Chat: &provider.ChatCapabilities{
+			StreamingDeltas:  true,
+			ShellCommandExec: true,
+			ThreadResume:     true,
+			ImageAttachments: true,
+		},
+	}
+}
+
 func (m *Manager) ID() string {
-	return "claude"
+	return m.Metadata().ID
 }
 
 func (m *Manager) CreateSession(folder string) (*chat.Session, error) {

--- a/internal/claudechat/manager_test.go
+++ b/internal/claudechat/manager_test.go
@@ -9,7 +9,34 @@ import (
 	"time"
 
 	"github.com/zevro-ai/remote-control-on-demand/internal/chat"
+	"github.com/zevro-ai/remote-control-on-demand/internal/provider"
 )
+
+func TestManagerMetadata(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(t.TempDir(), "")
+	metadata := mgr.Metadata()
+
+	if metadata.ID != "claude" {
+		t.Fatalf("metadata.ID = %q, want %q", metadata.ID, "claude")
+	}
+	if metadata.DisplayName != "Claude" {
+		t.Fatalf("metadata.DisplayName = %q, want %q", metadata.DisplayName, "Claude")
+	}
+	if metadata.Chat == nil {
+		t.Fatal("metadata.Chat = nil, want chat capabilities")
+	}
+	want := provider.ChatCapabilities{
+		StreamingDeltas:  true,
+		ShellCommandExec: true,
+		ThreadResume:     true,
+		ImageAttachments: true,
+	}
+	if *metadata.Chat != want {
+		t.Fatalf("metadata.Chat = %#v, want %#v", *metadata.Chat, want)
+	}
+}
 
 func TestParseExecOutputStreamsAndFinalizesMessage(t *testing.T) {
 	t.Parallel()

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -86,20 +86,7 @@ func testProviders(t *testing.T, sessionMgr *session.Manager, claudeMgr *claudec
 	}
 
 	if claudeMgr != nil {
-		claudeProvider, err := provider.NewChatAdapter(provider.Metadata{
-			ID:          "claude",
-			DisplayName: "Claude",
-			Chat: &provider.ChatCapabilities{
-				StreamingDeltas:  true,
-				ShellCommandExec: true,
-				ThreadResume:     true,
-				ImageAttachments: true,
-			},
-		}, claudeMgr)
-		if err != nil {
-			t.Fatalf("NewChatAdapter(claude): %v", err)
-		}
-		if err := registry.RegisterChat(claudeProvider); err != nil {
+		if err := registry.RegisterChat(claudeMgr); err != nil {
 			t.Fatalf("RegisterChat(claude): %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary
- make `claudechat.Manager` expose native provider metadata and register it directly in the provider registry
- keep Claude streaming and tool event behavior on the provider side while reusing the shared chat core
- add metadata coverage so the Claude chat capabilities stay explicit through future refactors

Closes #17

## Verification
- go test ./...
- go vet ./...
- go build -o /tmp/rcod ./cmd/rcodbot