### PR TITLE
feat: migrate Codex onto shared provider adapter

### DIFF
--- a/cmd/rcodbot/main.go
+++ b/cmd/rcodbot/main.go
@@ -150,21 +150,7 @@ func main() {
 			log.Fatalf("Registering Claude chat provider: %v", err)
 		}
 
-		codexProvider, err := provider.NewChatAdapter(provider.Metadata{
-			ID:          "codex",
-			DisplayName: "Codex",
-			Chat: &provider.ChatCapabilities{
-				StreamingDeltas:   true,
-				ToolCallStreaming: true,
-				ShellCommandExec:  true,
-				ThreadResume:      true,
-				ImageAttachments:  true,
-			},
-		}, codexMgr)
-		if err != nil {
-			log.Fatalf("Creating Codex chat provider registry entry: %v", err)
-		}
-		if err := registry.RegisterChat(codexProvider); err != nil {
+		if err := registry.RegisterChat(codexMgr); err != nil {
 			log.Fatalf("Registering Codex chat provider: %v", err)
 		}
 

--- a/internal/codex/manager.go
+++ b/internal/codex/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/zevro-ai/remote-control-on-demand/internal/bashcmd"
 	"github.com/zevro-ai/remote-control-on-demand/internal/chat"
 	"github.com/zevro-ai/remote-control-on-demand/internal/config"
+	"github.com/zevro-ai/remote-control-on-demand/internal/provider"
 )
 
 const (
@@ -43,8 +44,22 @@ func NewManager(baseFolder, statePath string) *Manager {
 	}
 }
 
+func (m *Manager) Metadata() provider.Metadata {
+	return provider.Metadata{
+		ID:          "codex",
+		DisplayName: "Codex",
+		Chat: &provider.ChatCapabilities{
+			StreamingDeltas:   true,
+			ToolCallStreaming: true,
+			ShellCommandExec:  true,
+			ThreadResume:      true,
+			ImageAttachments:  true,
+		},
+	}
+}
+
 func (m *Manager) ID() string {
-	return "codex"
+	return m.Metadata().ID
 }
 
 func (m *Manager) Restore() error {

--- a/internal/codex/manager_test.go
+++ b/internal/codex/manager_test.go
@@ -10,7 +10,35 @@ import (
 	"time"
 
 	"github.com/zevro-ai/remote-control-on-demand/internal/chat"
+	"github.com/zevro-ai/remote-control-on-demand/internal/provider"
 )
+
+func TestManagerMetadata(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(t.TempDir(), "")
+	metadata := mgr.Metadata()
+
+	if metadata.ID != "codex" {
+		t.Fatalf("metadata.ID = %q, want %q", metadata.ID, "codex")
+	}
+	if metadata.DisplayName != "Codex" {
+		t.Fatalf("metadata.DisplayName = %q, want %q", metadata.DisplayName, "Codex")
+	}
+	if metadata.Chat == nil {
+		t.Fatal("metadata.Chat = nil, want chat capabilities")
+	}
+	want := provider.ChatCapabilities{
+		StreamingDeltas:   true,
+		ToolCallStreaming: true,
+		ShellCommandExec:  true,
+		ThreadResume:      true,
+		ImageAttachments:  true,
+	}
+	if *metadata.Chat != want {
+		t.Fatalf("metadata.Chat = %#v, want %#v", *metadata.Chat, want)
+	}
+}
 
 func TestBuildCodexArgsNewSessionDangerousBypass(t *testing.T) {
 	sess := &chat.Session{RelName: "remote-control-on-demand"}

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -92,21 +92,7 @@ func testProviders(t *testing.T, sessionMgr *session.Manager, claudeMgr *claudec
 	}
 
 	if codexMgr != nil {
-		codexProvider, err := provider.NewChatAdapter(provider.Metadata{
-			ID:          "codex",
-			DisplayName: "Codex",
-			Chat: &provider.ChatCapabilities{
-				StreamingDeltas:   true,
-				ToolCallStreaming: true,
-				ShellCommandExec:  true,
-				ThreadResume:      true,
-				ImageAttachments:  true,
-			},
-		}, codexMgr)
-		if err != nil {
-			t.Fatalf("NewChatAdapter(codex): %v", err)
-		}
-		if err := registry.RegisterChat(codexProvider); err != nil {
+		if err := registry.RegisterChat(codexMgr); err != nil {
 			t.Fatalf("RegisterChat(codex): %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary
- make `codex.Manager` expose native provider metadata and register it directly in the provider registry
- keep Codex-specific CLI, resume, attachment, sandbox, and streaming behavior inside the Codex adapter on top of the shared chat core
- add metadata coverage so Codex capabilities stay explicit across future provider refactors

Closes #18

## Verification
- go test ./...
- go vet ./...
- go build -o /tmp/rcod ./cmd/rcodbot