### PR TITLE
fix: stop codex sessions resuming before first reply

### DIFF
--- a/internal/chat/chat.go
+++ b/internal/chat/chat.go
@@ -47,14 +47,15 @@ type Message struct {
 }
 
 type Session struct {
-	ID        string    `json:"id"`
-	Folder    string    `json:"folder"`
-	RelName   string    `json:"rel_name"`
-	ThreadID  string    `json:"thread_id,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	Busy      bool      `json:"busy"`
-	Messages  []Message `json:"messages,omitempty"`
+	ID          string    `json:"id"`
+	Folder      string    `json:"folder"`
+	RelName     string    `json:"rel_name"`
+	ThreadID    string    `json:"thread_id,omitempty"`
+	ThreadReady bool      `json:"thread_ready,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Busy        bool      `json:"busy"`
+	Messages    []Message `json:"messages,omitempty"`
 }
 
 type ToolCallEvent struct {

--- a/internal/chat/core.go
+++ b/internal/chat/core.go
@@ -131,6 +131,9 @@ func (c *Core) Restore() error {
 			continue
 		}
 		sess.Busy = false
+		if !sess.ThreadReady && sess.ThreadID != "" && sessionHasAssistantTextReply(sess) {
+			sess.ThreadReady = true
+		}
 		c.sessions[sess.ID] = sess
 	}
 	if _, ok := c.sessions[c.activeSessionID]; !ok {
@@ -138,6 +141,15 @@ func (c *Core) Restore() error {
 	}
 
 	return nil
+}
+
+func sessionHasAssistantTextReply(sess *Session) bool {
+	for _, msg := range sess.Messages {
+		if msg.Role == "assistant" && msg.Kind == "text" {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Core) CreateSession(folder string) (*Session, error) {

--- a/internal/chat/core_test.go
+++ b/internal/chat/core_test.go
@@ -46,6 +46,47 @@ func TestCoreRestoreResetsBusyState(t *testing.T) {
 	}
 }
 
+func TestCoreRestoreInfersThreadReadyFromAssistantReply(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "sessions.json")
+	now := time.Now().UTC()
+	data, err := json.Marshal(persistedState{
+		ActiveSessionID: "one",
+		Sessions: []*Session{
+			{
+				ID:        "one",
+				Folder:    "/tmp/demo",
+				RelName:   "demo",
+				ThreadID:  "019d-thread",
+				CreatedAt: now,
+				UpdatedAt: now,
+				Messages: []Message{
+					{Role: "user", Kind: "text", Content: "ping", Timestamp: now},
+					{Role: "assistant", Kind: "text", Content: "pong", Timestamp: now},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Marshal(): %v", err)
+	}
+	if err := os.WriteFile(statePath, data, 0600); err != nil {
+		t.Fatalf("WriteFile(): %v", err)
+	}
+
+	core := NewCore(t.TempDir(), statePath, 10)
+	if err := core.Restore(); err != nil {
+		t.Fatalf("Restore(): %v", err)
+	}
+
+	sess, ok := core.GetSession("one")
+	if !ok {
+		t.Fatal("expected restored session")
+	}
+	if !sess.ThreadReady {
+		t.Fatal("expected restored session to infer thread readiness from assistant reply")
+	}
+}
+
 func TestCoreCreateDeleteAndResolveActive(t *testing.T) {
 	baseDir := t.TempDir()
 	for _, name := range []string{"one", "two", "three"} {

--- a/internal/codex/manager.go
+++ b/internal/codex/manager.go
@@ -202,6 +202,7 @@ func (m *Manager) Send(ctx context.Context, id, prompt string, attachments []cha
 	clone, saveErr := request.Complete(func(current *chat.Session) *chat.Message {
 		if threadID != "" {
 			current.ThreadID = threadID
+			current.ThreadReady = true
 		}
 		if err != nil || reply == "" {
 			return nil
@@ -369,7 +370,7 @@ func buildCodexArgs(
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
 	}
 
-	if !hasAssistantReply(sess) {
+	if !sess.ThreadReady || sess.ThreadID == "" {
 		args = append(args, "--json")
 		if !dangerouslyBypassSandbox {
 			args = append(args, "--sandbox", sandbox)
@@ -390,15 +391,6 @@ func buildCodexArgs(
 	args = append(args, sess.ThreadID, prompt)
 	args = appendImageArgs(args, attachments)
 	return args
-}
-
-func hasAssistantReply(sess *chat.Session) bool {
-	for _, msg := range sess.Messages {
-		if msg.Role == "assistant" && msg.Kind == "text" {
-			return true
-		}
-	}
-	return false
 }
 
 func appendImageArgs(args []string, attachments []chat.Attachment) []string {

--- a/internal/codex/manager_test.go
+++ b/internal/codex/manager_test.go
@@ -105,8 +105,9 @@ func TestBuildCodexArgsNewSessionWithImages(t *testing.T) {
 
 func TestBuildCodexArgsResumeDangerousBypass(t *testing.T) {
 	sess := &chat.Session{
-		RelName:  "remote-control-on-demand",
-		ThreadID: "thread-123",
+		RelName:     "remote-control-on-demand",
+		ThreadID:    "thread-123",
+		ThreadReady: true,
 		Messages: []chat.Message{
 			{Role: "assistant", Kind: "text", Content: "done"},
 		},
@@ -131,8 +132,9 @@ func TestBuildCodexArgsResumeDangerousBypass(t *testing.T) {
 
 func TestBuildCodexArgsResumeWithImages(t *testing.T) {
 	sess := &chat.Session{
-		RelName:  "remote-control-on-demand",
-		ThreadID: "thread-123",
+		RelName:     "remote-control-on-demand",
+		ThreadID:    "thread-123",
+		ThreadReady: true,
 		Messages: []chat.Message{
 			{Role: "assistant", Kind: "text", Content: "done"},
 		},
@@ -298,6 +300,9 @@ func TestSendStartsNewCodexSessionWithoutResumeID(t *testing.T) {
 	if updated.ThreadID != "019d3066-632d-7d83-8be4-725ab37de218" {
 		t.Fatalf("updated.ThreadID = %q", updated.ThreadID)
 	}
+	if !updated.ThreadReady {
+		t.Fatal("updated.ThreadReady = false, want true after first successful Codex reply")
+	}
 }
 
 func TestBuildCodexArgsLegacyThreadIDWithoutAssistantReplyStartsFreshExec(t *testing.T) {
@@ -318,6 +323,33 @@ func TestBuildCodexArgsLegacyThreadIDWithoutAssistantReplyStartsFreshExec(t *tes
 		"--model",
 		"gpt-5",
 		initialPrompt(sess, "continue"),
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildCodexArgs() mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestBuildCodexArgsResumesThreadReadySessionWithoutAssistantTextInWindow(t *testing.T) {
+	sess := &chat.Session{
+		RelName:     "remote-control-on-demand",
+		ThreadID:    "019d-real-thread",
+		ThreadReady: true,
+		Messages: []chat.Message{
+			{Role: "user", Kind: "bash", Content: "ls"},
+			{Role: "assistant", Kind: "bash_result", Content: "file.txt"},
+		},
+	}
+
+	got := buildCodexArgs(sess, "continue", nil, "workspace-write", "gpt-5", false)
+	want := []string{
+		"exec",
+		"resume",
+		"--json",
+		"--model",
+		"gpt-5",
+		"019d-real-thread",
+		"continue",
 	}
 
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
## Summary
- stop pre-populating new chat sessions with a random `thread_id`
- let Codex persist the real session/thread id only after the first successful `thread.started` event
- add regression coverage so the first Codex message cannot accidentally go through `exec resume`

## Testing
- `go test ./internal/chat ./internal/codex`
- `go test ./...`

Fixes #48