### PR TITLE
feat: align runtime sessions and config with providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `cmd/rcodbot` entrypoint exposes Telegram as a chat interface for Codex:
 - switch between chat sessions with `/sessions` and `/use`
 - send a normal Telegram message to talk to Codex in the active repo
 - close old chat threads with `/close`
-- Codex respects `rc.permission_mode` from `config.yaml`; default is `workspace-write`, `bypassPermissions` opts into full local access, and other accepted values map to Codex sandbox modes
+- Codex respects `providers.codex.chat.permission_mode` from `config.yaml`; default is `workspace-write`, `bypassPermissions` opts into full local access, and other accepted values map to Codex sandbox modes
 
 Build and run it with:
 
@@ -101,10 +101,18 @@ telegram:
 
 rc:
   base_folder: "/home/user/Projects"
-  permission_mode: "workspace-write"
-  auto_restart: true
-  max_restarts: 3
-  restart_delay_seconds: 5
+
+providers:
+  claude:
+    runtime:
+      auto_restart: true
+      max_restarts: 3
+      restart_delay_seconds: 5
+    chat:
+      permission_mode: "workspace-write"
+  codex:
+    chat:
+      permission_mode: "workspace-write"
 ```
 
 See [config.example.yaml](./config.example.yaml) for a fuller example with notifications.
@@ -116,15 +124,16 @@ See [config.example.yaml](./config.example.yaml) for a fuller example with notif
 | `telegram.token` | Bot token from @BotFather |
 | `telegram.allowed_user_id` | Only this Telegram user can control the bot |
 | `rc.base_folder` | Directory RCOD scans for git repositories |
-| `rc.permission_mode` | `rcodbot` access mode for Codex sessions: `workspace-write` (default), `read-only`, `danger-full-access`, or `bypassPermissions` |
-| `rc.auto_restart` | Enables automatic restart for crashed sessions |
-| `rc.max_restarts` | Maximum restart attempts before giving up |
-| `rc.restart_delay_seconds` | Delay between restart attempts |
-| `rc.notifications.progress_update_interval` | Optional progress heartbeat interval, for example `10m` |
-| `rc.notifications.idle_timeout` | Optional idle notification threshold |
-| `rc.notifications.patterns` | Optional regex-based output notifications |
+| `providers.claude.runtime.auto_restart` | Enables automatic restart for crashed `claude rc` runtime sessions |
+| `providers.claude.runtime.max_restarts` | Maximum restart attempts before giving up |
+| `providers.claude.runtime.restart_delay_seconds` | Delay between restart attempts |
+| `providers.claude.runtime.notifications.*` | Optional runtime notification settings and progress heartbeats |
+| `providers.claude.chat.permission_mode` | Claude chat permission mode for `rcodbot` |
+| `providers.codex.chat.permission_mode` | Codex chat access mode: `workspace-write` (default), `read-only`, `danger-full-access`, or `bypassPermissions` |
 
 RCOD intentionally always starts Claude with `claude rc --permission-mode bypassPermissions`. This is not configurable.
+
+Legacy `rc.permission_mode`, `rc.auto_restart`, `rc.max_restarts`, `rc.restart_delay_seconds`, and `rc.notifications` are still accepted as fallbacks for older configs.
 
 ### Per-Project Overrides
 

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/zevro-ai/remote-control-on-demand/internal/bot"
 	"github.com/zevro-ai/remote-control-on-demand/internal/config"
@@ -81,15 +80,16 @@ func main() {
 		log.Fatalf("Creating state directory: %v", err)
 	}
 
+	claudeRuntime := cfg.ClaudeRuntimeSettings()
 	statePath := runtimepaths.ResolveStatePath(*configPath, *stateDir, "sessions.json")
 	mgr := session.NewManager(
 		runner,
-		cfg.RC.BaseFolder,
+		claudeRuntime.BaseFolder,
 		statePath,
-		cfg.RC.AutoRestart,
-		cfg.RC.MaxRestarts,
-		time.Duration(cfg.RC.RestartDelaySeconds)*time.Second,
-		cfg.RC.Notifications,
+		claudeRuntime.AutoRestart,
+		claudeRuntime.MaxRestarts,
+		claudeRuntime.RestartDelay,
+		claudeRuntime.Notifications,
 	)
 
 	if err := mgr.Restore(); err != nil {

--- a/cmd/rcodbot/main.go
+++ b/cmd/rcodbot/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/zevro-ai/remote-control-on-demand/internal/claudechat"
 	"github.com/zevro-ai/remote-control-on-demand/internal/codex"
@@ -88,14 +87,15 @@ func main() {
 	}
 
 	sessionStatePath := runtimepaths.ResolveStatePath(*configPath, *stateDir, "sessions.json")
+	claudeRuntime := cfg.ClaudeRuntimeSettings()
 	sessionMgr := session.NewManager(
 		runner,
-		cfg.RC.BaseFolder,
+		claudeRuntime.BaseFolder,
 		sessionStatePath,
-		cfg.RC.AutoRestart,
-		cfg.RC.MaxRestarts,
-		time.Duration(cfg.RC.RestartDelaySeconds)*time.Second,
-		cfg.RC.Notifications,
+		claudeRuntime.AutoRestart,
+		claudeRuntime.MaxRestarts,
+		claudeRuntime.RestartDelay,
+		claudeRuntime.Notifications,
 	)
 	if err := sessionMgr.Restore(); err != nil {
 		log.Printf("Warning: Failed to restore Claude sessions: %v", err)
@@ -103,14 +103,14 @@ func main() {
 
 	codexStatePath := runtimepaths.ResolveStatePath(*configPath, *stateDir, "codex_sessions.json")
 	codexMgr := codex.NewManager(cfg.RC.BaseFolder, codexStatePath)
-	codexMgr.ConfigurePermissionMode(cfg.RC.PermissionMode)
+	codexMgr.ConfigurePermissionMode(cfg.CodexChatPermissionMode())
 	if err := codexMgr.Restore(); err != nil {
 		log.Fatalf("Restoring Codex sessions: %v", err)
 	}
 
 	claudeStatePath := runtimepaths.ResolveStatePath(*configPath, *stateDir, "claude_sessions.json")
 	claudeMgr := claudechat.NewManager(cfg.RC.BaseFolder, claudeStatePath)
-	claudeMgr.ConfigurePermissionMode(cfg.RC.PermissionMode)
+	claudeMgr.ConfigurePermissionMode(cfg.ClaudeChatPermissionMode())
 	if err := claudeMgr.Restore(); err != nil {
 		log.Fatalf("Restoring Claude chat sessions: %v", err)
 	}
@@ -135,7 +135,7 @@ func main() {
 			DisplayName: "Claude",
 			Runtime: &provider.RuntimeCapabilities{
 				LongRunningProcesses: true,
-				AutoRestart:          cfg.RC.AutoRestart,
+				AutoRestart:          claudeRuntime.AutoRestart,
 				ExternalURLDetection: true,
 			},
 		}, sessionMgr)
@@ -154,7 +154,7 @@ func main() {
 			log.Fatalf("Registering Codex chat provider: %v", err)
 		}
 
-		httpSrv = httpapi.NewServer(cfg.API, runtimeProvider, registry)
+		httpSrv = httpapi.NewServer(cfg.API, "claude", registry)
 		go httpSrv.Start()
 	}
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,22 +9,28 @@ telegram:
 
 rc:
   base_folder: "/home/user/Projects"
-  permission_mode: "workspace-write"  # rcodbot only; use bypassPermissions only for full local access
-  auto_restart: true
-  max_restarts: 3
-  restart_delay_seconds: 5
 
-  # RCOD always starts Claude with:
-  # claude rc --permission-mode bypassPermissions
+providers:
+  claude:
+    chat:
+      permission_mode: "workspace-write"
+    runtime:
+      auto_restart: true
+      max_restarts: 3
+      restart_delay_seconds: 5
 
-  # Session event notifications (optional)
-  # notifications:
-  #   progress_update_interval: 10m  # Periodic Telegram heartbeat for active sessions
-  #   idle_timeout: 5m          # Notify when no output for this duration (0 = disabled)
-  #   patterns:                  # Regex patterns to match in session output
-  #     - name: "task_completed"
-  #       regex: "(?i)(task completed|all done)"
-  #       once: true             # Only notify once per session
-  #     - name: "error"
-  #       regex: "(?i)(error:|fatal|panic:)"
-  #       # once: false (default) — notify every match (throttled to max once per 30s)
+      # Session event notifications (optional)
+      # notifications:
+      #   progress_update_interval: 10m  # Periodic Telegram heartbeat for active sessions
+      #   idle_timeout: 5m               # Notify when no output for this duration (0 = disabled)
+      #   patterns:
+      #     - name: "task_completed"
+      #       regex: "(?i)(task completed|all done)"
+      #       once: true
+      #     - name: "error"
+      #       regex: "(?i)(error:|fatal|panic:)"
+      #       # once: false (default)
+
+  codex:
+    chat:
+      permission_mode: "workspace-write"  # use bypassPermissions only for full local access

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,9 +17,10 @@ type APIConfig struct {
 }
 
 type Config struct {
-	Telegram TelegramConfig `yaml:"telegram"`
-	RC       RCConfig       `yaml:"rc"`
-	API      APIConfig      `yaml:"api,omitempty"`
+	Telegram  TelegramConfig  `yaml:"telegram"`
+	RC        RCConfig        `yaml:"rc"`
+	Providers ProvidersConfig `yaml:"providers,omitempty"`
+	API       APIConfig       `yaml:"api,omitempty"`
 }
 
 type TelegramConfig struct {
@@ -30,10 +31,43 @@ type TelegramConfig struct {
 type RCConfig struct {
 	BaseFolder          string               `yaml:"base_folder"`
 	PermissionMode      string               `yaml:"permission_mode,omitempty"`
-	AutoRestart         bool                 `yaml:"auto_restart"`
-	MaxRestarts         int                  `yaml:"max_restarts"`
-	RestartDelaySeconds int                  `yaml:"restart_delay_seconds"`
+	AutoRestart         bool                 `yaml:"auto_restart,omitempty"`
+	MaxRestarts         int                  `yaml:"max_restarts,omitempty"`
+	RestartDelaySeconds int                  `yaml:"restart_delay_seconds,omitempty"`
 	Notifications       *NotificationsConfig `yaml:"notifications,omitempty"`
+}
+
+type ProvidersConfig struct {
+	Claude ClaudeProviderConfig `yaml:"claude,omitempty"`
+	Codex  CodexProviderConfig  `yaml:"codex,omitempty"`
+}
+
+type ClaudeProviderConfig struct {
+	Chat    ProviderChatConfig    `yaml:"chat,omitempty"`
+	Runtime ProviderRuntimeConfig `yaml:"runtime,omitempty"`
+}
+
+type CodexProviderConfig struct {
+	Chat ProviderChatConfig `yaml:"chat,omitempty"`
+}
+
+type ProviderChatConfig struct {
+	PermissionMode string `yaml:"permission_mode,omitempty"`
+}
+
+type ProviderRuntimeConfig struct {
+	AutoRestart         *bool                `yaml:"auto_restart,omitempty"`
+	MaxRestarts         *int                 `yaml:"max_restarts,omitempty"`
+	RestartDelaySeconds *int                 `yaml:"restart_delay_seconds,omitempty"`
+	Notifications       *NotificationsConfig `yaml:"notifications,omitempty"`
+}
+
+type RuntimeSettings struct {
+	BaseFolder    string
+	AutoRestart   bool
+	MaxRestarts   int
+	RestartDelay  time.Duration
+	Notifications *NotificationsConfig
 }
 
 const (
@@ -159,6 +193,9 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("rc.notifications: %w", err)
 		}
 	}
+	if err := c.Providers.Validate(); err != nil {
+		return fmt.Errorf("providers: %w", err)
+	}
 
 	return nil
 }
@@ -178,6 +215,101 @@ func ValidateCodexPermissionMode(permissionMode string) error {
 	default:
 		return fmt.Errorf("must be one of %q, %q, %q, or %q", PermissionModeBypass, PermissionModeReadOnly, PermissionModeWorkspace, PermissionModeDangerFull)
 	}
+}
+
+func (p ProvidersConfig) Validate() error {
+	if err := p.Claude.Validate(); err != nil {
+		return fmt.Errorf("claude: %w", err)
+	}
+	if err := p.Codex.Validate(); err != nil {
+		return fmt.Errorf("codex: %w", err)
+	}
+	return nil
+}
+
+func (p ClaudeProviderConfig) Validate() error {
+	if err := p.Chat.Validate(); err != nil {
+		return fmt.Errorf("chat: %w", err)
+	}
+	if err := p.Runtime.Validate(); err != nil {
+		return fmt.Errorf("runtime: %w", err)
+	}
+	return nil
+}
+
+func (p CodexProviderConfig) Validate() error {
+	if err := p.Chat.Validate(); err != nil {
+		return fmt.Errorf("chat: %w", err)
+	}
+	return nil
+}
+
+func (p ProviderChatConfig) Validate() error {
+	if strings.TrimSpace(p.PermissionMode) == "" {
+		return nil
+	}
+	return ValidateCodexPermissionMode(p.PermissionMode)
+}
+
+func (p ProviderRuntimeConfig) Validate() error {
+	if p.MaxRestarts != nil && *p.MaxRestarts < 0 {
+		return fmt.Errorf("max_restarts must be >= 0")
+	}
+	if p.RestartDelaySeconds != nil && *p.RestartDelaySeconds < 0 {
+		return fmt.Errorf("restart_delay_seconds must be >= 0")
+	}
+	if p.Notifications != nil {
+		if err := p.Notifications.Validate(); err != nil {
+			return fmt.Errorf("notifications: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c *Config) ClaudeRuntimeSettings() RuntimeSettings {
+	runtimeCfg := c.Providers.Claude.Runtime
+
+	autoRestart := c.RC.AutoRestart
+	if runtimeCfg.AutoRestart != nil {
+		autoRestart = *runtimeCfg.AutoRestart
+	}
+
+	maxRestarts := c.RC.MaxRestarts
+	if runtimeCfg.MaxRestarts != nil {
+		maxRestarts = *runtimeCfg.MaxRestarts
+	}
+
+	restartDelaySeconds := c.RC.RestartDelaySeconds
+	if runtimeCfg.RestartDelaySeconds != nil {
+		restartDelaySeconds = *runtimeCfg.RestartDelaySeconds
+	}
+
+	notifications := c.RC.Notifications
+	if runtimeCfg.Notifications != nil {
+		notifications = runtimeCfg.Notifications
+	}
+
+	return RuntimeSettings{
+		BaseFolder:    c.RC.BaseFolder,
+		AutoRestart:   autoRestart,
+		MaxRestarts:   maxRestarts,
+		RestartDelay:  time.Duration(restartDelaySeconds) * time.Second,
+		Notifications: notifications,
+	}
+}
+
+func (c *Config) ClaudeChatPermissionMode() string {
+	if mode := strings.TrimSpace(c.Providers.Claude.Chat.PermissionMode); mode != "" {
+		return NormalizeCodexPermissionMode(mode)
+	}
+	return NormalizeCodexPermissionMode(c.RC.PermissionMode)
+}
+
+func (c *Config) CodexChatPermissionMode() string {
+	if mode := strings.TrimSpace(c.Providers.Codex.Chat.PermissionMode); mode != "" {
+		return NormalizeCodexPermissionMode(mode)
+	}
+	return NormalizeCodexPermissionMode(c.RC.PermissionMode)
 }
 
 func (c *Config) Save(path string) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -291,3 +291,110 @@ func TestConfigValidatePermissionMode(t *testing.T) {
 		t.Fatalf("expected rc.permission_mode error, got %v", err)
 	}
 }
+
+func TestConfigValidateProviderSpecificSettings(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := &Config{
+		Telegram: TelegramConfig{
+			Token:         "token",
+			AllowedUserID: 123,
+		},
+		RC: RCConfig{
+			BaseFolder: tmpDir,
+		},
+		Providers: ProvidersConfig{
+			Claude: ClaudeProviderConfig{
+				Chat: ProviderChatConfig{
+					PermissionMode: "plan",
+				},
+			},
+		},
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected invalid provider-specific permission mode error")
+	}
+	if !strings.Contains(err.Error(), "providers: claude: chat") {
+		t.Fatalf("expected providers claude chat error, got %v", err)
+	}
+}
+
+func TestConfigResolvedProviderSettings(t *testing.T) {
+	cfg := &Config{
+		RC: RCConfig{
+			BaseFolder:          "/tmp/projects",
+			PermissionMode:      PermissionModeReadOnly,
+			AutoRestart:         true,
+			MaxRestarts:         3,
+			RestartDelaySeconds: 5,
+			Notifications: &NotificationsConfig{
+				IdleTimeout: Duration(5 * time.Minute),
+			},
+		},
+		Providers: ProvidersConfig{
+			Claude: ClaudeProviderConfig{
+				Chat: ProviderChatConfig{
+					PermissionMode: PermissionModeDangerFull,
+				},
+				Runtime: ProviderRuntimeConfig{
+					AutoRestart:         boolPtr(false),
+					MaxRestarts:         intPtr(9),
+					RestartDelaySeconds: intPtr(12),
+				},
+			},
+			Codex: CodexProviderConfig{
+				Chat: ProviderChatConfig{
+					PermissionMode: PermissionModeWorkspace,
+				},
+			},
+		},
+	}
+
+	runtimeSettings := cfg.ClaudeRuntimeSettings()
+	if runtimeSettings.BaseFolder != "/tmp/projects" {
+		t.Fatalf("BaseFolder = %q", runtimeSettings.BaseFolder)
+	}
+	if runtimeSettings.AutoRestart {
+		t.Fatal("expected provider runtime auto_restart override to disable restarts")
+	}
+	if runtimeSettings.MaxRestarts != 9 {
+		t.Fatalf("MaxRestarts = %d, want 9", runtimeSettings.MaxRestarts)
+	}
+	if runtimeSettings.RestartDelay != 12*time.Second {
+		t.Fatalf("RestartDelay = %v, want 12s", runtimeSettings.RestartDelay)
+	}
+	if runtimeSettings.Notifications == nil || time.Duration(runtimeSettings.Notifications.IdleTimeout) != 5*time.Minute {
+		t.Fatalf("Notifications = %#v", runtimeSettings.Notifications)
+	}
+	if cfg.ClaudeChatPermissionMode() != PermissionModeDangerFull {
+		t.Fatalf("ClaudeChatPermissionMode() = %q", cfg.ClaudeChatPermissionMode())
+	}
+	if cfg.CodexChatPermissionMode() != PermissionModeWorkspace {
+		t.Fatalf("CodexChatPermissionMode() = %q", cfg.CodexChatPermissionMode())
+	}
+}
+
+func TestConfigResolvedProviderSettingsFallbackToLegacyRC(t *testing.T) {
+	cfg := &Config{
+		RC: RCConfig{
+			BaseFolder:          "/tmp/projects",
+			PermissionMode:      PermissionModeWorkspace,
+			AutoRestart:         true,
+			MaxRestarts:         2,
+			RestartDelaySeconds: 7,
+		},
+	}
+
+	runtimeSettings := cfg.ClaudeRuntimeSettings()
+	if !runtimeSettings.AutoRestart || runtimeSettings.MaxRestarts != 2 || runtimeSettings.RestartDelay != 7*time.Second {
+		t.Fatalf("runtime settings = %#v", runtimeSettings)
+	}
+	if cfg.ClaudeChatPermissionMode() != PermissionModeWorkspace {
+		t.Fatalf("ClaudeChatPermissionMode() = %q", cfg.ClaudeChatPermissionMode())
+	}
+	if cfg.CodexChatPermissionMode() != PermissionModeWorkspace {
+		t.Fatalf("CodexChatPermissionMode() = %q", cfg.CodexChatPermissionMode())
+	}
+}

--- a/internal/config/onboarding.go
+++ b/internal/config/onboarding.go
@@ -78,6 +78,9 @@ func stepOK(s string) string       { return styled(fBold+fGreen, "  ✓ ") + s }
 func promptArrow() string          { return styled(fBrCyan, "  › ") }
 func summaryLabel(s string) string { return styled(fDim, s) }
 
+func boolPtr(value bool) *bool { return &value }
+func intPtr(value int) *int    { return &value }
+
 // selectFromList renders an interactive menu navigable with arrow keys.
 // Returns the index of the selected option.
 func selectFromList(labels []string, defaultIdx int) (int, error) {
@@ -376,12 +379,25 @@ func RunOnboarding(configPath string) (*Config, error) {
 		},
 		API: apiCfg,
 		RC: RCConfig{
-			BaseFolder:          baseFolder,
-			PermissionMode:      DefaultCodexPermissionMode,
-			AutoRestart:         autoRestart,
-			MaxRestarts:         maxRestarts,
-			RestartDelaySeconds: restartDelay,
-			Notifications:       notifications,
+			BaseFolder: baseFolder,
+		},
+		Providers: ProvidersConfig{
+			Claude: ClaudeProviderConfig{
+				Chat: ProviderChatConfig{
+					PermissionMode: DefaultCodexPermissionMode,
+				},
+				Runtime: ProviderRuntimeConfig{
+					AutoRestart:         boolPtr(autoRestart),
+					MaxRestarts:         intPtr(maxRestarts),
+					RestartDelaySeconds: intPtr(restartDelay),
+					Notifications:       notifications,
+				},
+			},
+			Codex: CodexProviderConfig{
+				Chat: ProviderChatConfig{
+					PermissionMode: DefaultCodexPermissionMode,
+				},
+			},
 		},
 	}
 
@@ -392,7 +408,7 @@ func RunOnboarding(configPath string) (*Config, error) {
 	fmt.Printf("    %s  %s\n", summaryLabel("Token          "), tokenPreview)
 	fmt.Printf("    %s  %d\n", summaryLabel("User ID        "), userID)
 	fmt.Printf("    %s  %s\n", summaryLabel("Projects folder"), baseFolder)
-	fmt.Printf("    %s  %s\n", summaryLabel("Codex access   "), cfg.RC.PermissionMode)
+	fmt.Printf("    %s  %s\n", summaryLabel("Codex access   "), cfg.CodexChatPermissionMode())
 	if autoRestart {
 		fmt.Printf("    %s  enabled (%d max, %ds delay)\n", summaryLabel("Auto-restart   "), maxRestarts, restartDelay)
 	} else {

--- a/internal/config/onboarding_test.go
+++ b/internal/config/onboarding_test.go
@@ -33,6 +33,12 @@ func TestRunOnboardingEnablesDashboardAndWritesConfig(t *testing.T) {
 	if cfg.API.Token != "generated-dashboard-token" {
 		t.Fatalf("expected generated dashboard token to be saved, got %q", cfg.API.Token)
 	}
+	if cfg.CodexChatPermissionMode() != DefaultCodexPermissionMode {
+		t.Fatalf("expected codex permission mode %q, got %q", DefaultCodexPermissionMode, cfg.CodexChatPermissionMode())
+	}
+	if cfg.ClaudeRuntimeSettings().AutoRestart {
+		t.Fatal("expected onboarding fixture to keep claude runtime auto_restart disabled")
+	}
 
 	if !strings.Contains(output, "Dashboard URL: http://127.0.0.1:3001/") {
 		t.Fatalf("expected output to include dashboard URL, got %q", output)
@@ -54,6 +60,9 @@ func TestRunOnboardingEnablesDashboardAndWritesConfig(t *testing.T) {
 	}
 	if !strings.Contains(configYAML, "token: generated-dashboard-token") {
 		t.Fatalf("expected saved config to include dashboard token, got %q", configYAML)
+	}
+	if !strings.Contains(configYAML, "providers:\n") || !strings.Contains(configYAML, "claude:\n") || !strings.Contains(configYAML, "codex:\n") {
+		t.Fatalf("expected saved config to include provider sections, got %q", configYAML)
 	}
 }
 

--- a/internal/httpapi/handlers.go
+++ b/internal/httpapi/handlers.go
@@ -16,13 +16,14 @@ import (
 )
 
 func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
-	if s.runtimeProvider == nil {
+	runtimeProvider, ok := s.defaultRuntimeProvider()
+	if !ok {
 		writeJSON(w, http.StatusOK, []sessionResponse{})
 		return
 	}
 
-	metadata := s.runtimeProvider.Metadata()
-	sessions := s.runtimeProvider.ListSessions()
+	metadata := runtimeProvider.Metadata()
+	sessions := runtimeProvider.ListSessions()
 	resp := make([]sessionResponse, 0, len(sessions))
 	for _, sess := range sessions {
 		resp = append(resp, toSessionResponse(sess, metadata))
@@ -31,7 +32,8 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
-	if s.runtimeProvider == nil {
+	runtimeProvider, ok := s.defaultRuntimeProvider()
+	if !ok {
 		writeJSON(w, http.StatusNotFound, errorResponse{Error: "runtime provider not configured"})
 		return
 	}
@@ -41,22 +43,27 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request body"})
 		return
 	}
-	sess, err := s.runtimeProvider.CreateSession(req.Folder)
+	sess, err := runtimeProvider.CreateSession(req.Folder)
 	if err != nil {
 		writeManagerError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusCreated, toSessionResponse(sess, s.runtimeProvider.Metadata()))
+	writeJSON(w, http.StatusCreated, toSessionResponse(sess, runtimeProvider.Metadata()))
 }
 
 func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
-	if s.runtimeProvider == nil {
-		writeJSON(w, http.StatusNotFound, errorResponse{Error: "runtime provider not configured"})
+	runtimeProvider, _, ok := s.findRuntimeProviderBySessionID(r.PathValue("id"))
+	if !ok {
+		if _, exists := s.defaultRuntimeProvider(); !exists {
+			writeJSON(w, http.StatusNotFound, errorResponse{Error: "runtime provider not configured"})
+			return
+		}
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "session not found"})
 		return
 	}
 
 	id := r.PathValue("id")
-	if err := s.runtimeProvider.DeleteSession(id); err != nil {
+	if err := runtimeProvider.DeleteSession(id); err != nil {
 		writeManagerError(w, err)
 		return
 	}
@@ -64,32 +71,32 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleRestartSession(w http.ResponseWriter, r *http.Request) {
-	if s.runtimeProvider == nil {
-		writeJSON(w, http.StatusNotFound, errorResponse{Error: "runtime provider not configured"})
+	runtimeProvider, metadata, ok := s.findRuntimeProviderBySessionID(r.PathValue("id"))
+	if !ok {
+		if _, exists := s.defaultRuntimeProvider(); !exists {
+			writeJSON(w, http.StatusNotFound, errorResponse{Error: "runtime provider not configured"})
+			return
+		}
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "session not found"})
 		return
 	}
 
 	id := r.PathValue("id")
-	if err := s.runtimeProvider.RestartSession(id); err != nil {
+	if err := runtimeProvider.RestartSession(id); err != nil {
 		writeManagerError(w, err)
 		return
 	}
-	sess, ok := s.runtimeProvider.GetSession(id)
+	sess, ok := runtimeProvider.GetSession(id)
 	if !ok {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "restarted"})
 		return
 	}
-	writeJSON(w, http.StatusOK, toSessionResponse(sess, s.runtimeProvider.Metadata()))
+	writeJSON(w, http.StatusOK, toSessionResponse(sess, metadata))
 }
 
 func (s *Server) handleSessionLogs(w http.ResponseWriter, r *http.Request) {
-	if s.runtimeProvider == nil {
-		writeJSON(w, http.StatusNotFound, errorResponse{Error: "runtime provider not configured"})
-		return
-	}
-
 	id := r.PathValue("id")
-	sess, ok := s.runtimeProvider.GetSession(id)
+	_, _, sess, ok := s.findRuntimeSession(id)
 	if !ok {
 		writeJSON(w, http.StatusNotFound, errorResponse{Error: "session not found"})
 		return
@@ -104,6 +111,94 @@ func (s *Server) handleSessionLogs(w http.ResponseWriter, r *http.Request) {
 
 	lines := sess.SnapshotLogs(n)
 	writeJSON(w, http.StatusOK, map[string]interface{}{"lines": lines})
+}
+
+func (s *Server) handleListProviderRuntimeSessions(w http.ResponseWriter, r *http.Request) {
+	runtimeProvider, metadata, ok := s.getRuntimeProvider(w, r)
+	if !ok {
+		return
+	}
+
+	sessions := runtimeProvider.ListSessions()
+	resp := make([]sessionResponse, 0, len(sessions))
+	for _, sess := range sessions {
+		resp = append(resp, toSessionResponse(sess, metadata))
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (s *Server) handleCreateProviderRuntimeSession(w http.ResponseWriter, r *http.Request) {
+	runtimeProvider, metadata, ok := s.getRuntimeProvider(w, r)
+	if !ok {
+		return
+	}
+
+	var req createSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request body"})
+		return
+	}
+
+	sess, err := runtimeProvider.CreateSession(req.Folder)
+	if err != nil {
+		writeManagerError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, toSessionResponse(sess, metadata))
+}
+
+func (s *Server) handleDeleteProviderRuntimeSession(w http.ResponseWriter, r *http.Request) {
+	runtimeProvider, _, ok := s.getRuntimeProvider(w, r)
+	if !ok {
+		return
+	}
+
+	if err := runtimeProvider.DeleteSession(r.PathValue("id")); err != nil {
+		writeManagerError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleRestartProviderRuntimeSession(w http.ResponseWriter, r *http.Request) {
+	runtimeProvider, metadata, ok := s.getRuntimeProvider(w, r)
+	if !ok {
+		return
+	}
+
+	id := r.PathValue("id")
+	if err := runtimeProvider.RestartSession(id); err != nil {
+		writeManagerError(w, err)
+		return
+	}
+	sess, ok := runtimeProvider.GetSession(id)
+	if !ok {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "restarted"})
+		return
+	}
+	writeJSON(w, http.StatusOK, toSessionResponse(sess, metadata))
+}
+
+func (s *Server) handleProviderRuntimeSessionLogs(w http.ResponseWriter, r *http.Request) {
+	runtimeProvider, _, ok := s.getRuntimeProvider(w, r)
+	if !ok {
+		return
+	}
+
+	sess, ok := runtimeProvider.GetSession(r.PathValue("id"))
+	if !ok {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "session not found"})
+		return
+	}
+
+	n := 50
+	if qn := r.URL.Query().Get("lines"); qn != "" {
+		if parsed, err := strconv.Atoi(qn); err == nil && parsed > 0 {
+			n = parsed
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"lines": sess.SnapshotLogs(n)})
 }
 
 // Generic Chat Provider Handlers
@@ -126,6 +221,15 @@ func (s *Server) handleListProviderMetadata(w http.ResponseWriter, r *http.Reque
 			continue
 		}
 		providers = append(providers, toProviderMetadataResponse(tool.Metadata))
+	}
+	writeJSON(w, http.StatusOK, providers)
+}
+
+func (s *Server) handleListRuntimeProviderMetadata(w http.ResponseWriter, r *http.Request) {
+	runtimeProviders := s.registry.RuntimeProviders()
+	providers := make([]providerMetadataResponse, 0, len(runtimeProviders))
+	for _, runtimeProvider := range runtimeProviders {
+		providers = append(providers, toProviderMetadataResponse(runtimeProvider.Metadata()))
 	}
 	writeJSON(w, http.StatusOK, providers)
 }
@@ -294,13 +398,89 @@ func (s *Server) getProvider(w http.ResponseWriter, r *http.Request) (provider.C
 	return p, true
 }
 
+func (s *Server) getRuntimeProvider(w http.ResponseWriter, r *http.Request) (provider.RuntimeProvider, provider.Metadata, bool) {
+	id := strings.TrimSpace(r.PathValue("provider"))
+	if id == "" {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: "runtime provider not configured"})
+		return nil, provider.Metadata{}, false
+	}
+
+	runtimeProvider, ok := s.registry.RuntimeProvider(id)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, errorResponse{Error: fmt.Sprintf("runtime provider %q not found", id)})
+		return nil, provider.Metadata{}, false
+	}
+	return runtimeProvider, runtimeProvider.Metadata(), true
+}
+
+func (s *Server) defaultRuntimeProvider() (provider.RuntimeProvider, bool) {
+	if s.registry == nil {
+		return nil, false
+	}
+
+	if s.defaultRuntimeProviderID != "" {
+		runtimeProvider, ok := s.registry.RuntimeProvider(s.defaultRuntimeProviderID)
+		if ok {
+			return runtimeProvider, true
+		}
+	}
+
+	runtimeProviders := s.registry.RuntimeProviders()
+	if len(runtimeProviders) == 1 {
+		return runtimeProviders[0], true
+	}
+
+	return nil, false
+}
+
+func (s *Server) findRuntimeProviderBySessionID(sessionID string) (provider.RuntimeProvider, provider.Metadata, bool) {
+	if sessionID == "" || s.registry == nil {
+		return nil, provider.Metadata{}, false
+	}
+
+	if runtimeProvider, ok := s.defaultRuntimeProvider(); ok {
+		if _, exists := runtimeProvider.GetSession(sessionID); exists {
+			return runtimeProvider, runtimeProvider.Metadata(), true
+		}
+	}
+
+	for _, runtimeProvider := range s.registry.RuntimeProviders() {
+		if _, exists := runtimeProvider.GetSession(sessionID); exists {
+			return runtimeProvider, runtimeProvider.Metadata(), true
+		}
+	}
+
+	return nil, provider.Metadata{}, false
+}
+
+func (s *Server) findRuntimeSession(sessionID string) (provider.RuntimeProvider, provider.Metadata, provider.RuntimeSession, bool) {
+	runtimeProvider, metadata, ok := s.findRuntimeProviderBySessionID(sessionID)
+	if !ok {
+		return nil, provider.Metadata{}, nil, false
+	}
+
+	sess, ok := runtimeProvider.GetSession(sessionID)
+	if !ok {
+		return nil, provider.Metadata{}, nil, false
+	}
+	return runtimeProvider, metadata, sess, true
+}
+
 func (s *Server) handleListFolders(w http.ResponseWriter, r *http.Request) {
-	if s.runtimeProvider == nil {
+	runtimeProvider, ok := s.defaultRuntimeProvider()
+	if !ok {
 		writeJSON(w, http.StatusOK, []string{})
 		return
 	}
-	folders := s.runtimeProvider.ListFolders()
-	writeJSON(w, http.StatusOK, folders)
+	writeJSON(w, http.StatusOK, runtimeProvider.ListFolders())
+}
+
+func (s *Server) handleListProviderFolders(w http.ResponseWriter, r *http.Request) {
+	runtimeProvider, _, ok := s.getRuntimeProvider(w, r)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, runtimeProvider.ListFolders())
 }
 
 func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {

--- a/internal/httpapi/server.go
+++ b/internal/httpapi/server.go
@@ -19,28 +19,28 @@ import (
 )
 
 type Server struct {
-	cfg             config.APIConfig
-	runtimeProvider provider.RuntimeProvider
-	registry        *provider.Registry
-	hub             *Hub
-	httpServer      *http.Server
-	uploadDir       string
-	spaFS           fs.FS
+	cfg                      config.APIConfig
+	defaultRuntimeProviderID string
+	registry                 *provider.Registry
+	hub                      *Hub
+	httpServer               *http.Server
+	uploadDir                string
+	spaFS                    fs.FS
 }
 
-func NewServer(cfg config.APIConfig, runtimeProvider provider.RuntimeProvider, registry *provider.Registry) *Server {
+func NewServer(cfg config.APIConfig, defaultRuntimeProviderID string, registry *provider.Registry) *Server {
 	spaFS := dashboard.FS()
 	if registry == nil {
 		registry = provider.NewRegistry()
 	}
 
 	return &Server{
-		cfg:             cfg,
-		runtimeProvider: runtimeProvider,
-		registry:        registry,
-		hub:             newHub(),
-		uploadDir:       filepath.Join(".rcodbot", "uploads"),
-		spaFS:           spaFS,
+		cfg:                      cfg,
+		defaultRuntimeProviderID: strings.TrimSpace(defaultRuntimeProviderID),
+		registry:                 registry,
+		hub:                      newHub(),
+		uploadDir:                filepath.Join(".rcodbot", "uploads"),
+		spaFS:                    spaFS,
 	}
 }
 
@@ -53,6 +53,13 @@ func (s *Server) Start() {
 	mux.HandleFunc("DELETE /api/sessions/{id}", s.handleDeleteSession)
 	mux.HandleFunc("POST /api/sessions/{id}/restart", s.handleRestartSession)
 	mux.HandleFunc("GET /api/sessions/{id}/logs", s.handleSessionLogs)
+	mux.HandleFunc("GET /api/runtime/providers", s.handleListRuntimeProviderMetadata)
+	mux.HandleFunc("GET /api/runtime/{provider}/sessions", s.handleListProviderRuntimeSessions)
+	mux.HandleFunc("POST /api/runtime/{provider}/sessions", s.handleCreateProviderRuntimeSession)
+	mux.HandleFunc("DELETE /api/runtime/{provider}/sessions/{id}", s.handleDeleteProviderRuntimeSession)
+	mux.HandleFunc("POST /api/runtime/{provider}/sessions/{id}/restart", s.handleRestartProviderRuntimeSession)
+	mux.HandleFunc("GET /api/runtime/{provider}/sessions/{id}/logs", s.handleProviderRuntimeSessionLogs)
+	mux.HandleFunc("GET /api/runtime/{provider}/folders", s.handleListProviderFolders)
 
 	// Generic Chat Provider API
 	mux.HandleFunc("GET /api/providers", s.handleListProviderMetadata)
@@ -78,7 +85,7 @@ func (s *Server) Start() {
 	handler = authMiddleware(s.cfg.Token, handler)
 	handler = corsMiddleware(s.cfg.Token, handler)
 
-	s.hub.start(s.runtimeProvider, s.registry)
+	s.hub.start(s.registry)
 
 	s.httpServer = &http.Server{
 		Addr:              fmt.Sprintf(":%d", s.cfg.Port),

--- a/internal/httpapi/server_test.go
+++ b/internal/httpapi/server_test.go
@@ -41,8 +41,8 @@ func setupTestServer(t *testing.T) (*Server, *http.ServeMux) {
 func setupTestServerWithManagers(t *testing.T, sessionMgr *session.Manager, claudeMgr *claudechat.Manager, codexMgr *codex.Manager) (*Server, *http.ServeMux) {
 	t.Helper()
 
-	runtimeProvider, registry := testProviders(t, sessionMgr, claudeMgr, codexMgr)
-	srv := NewServer(config.APIConfig{Port: 0, Token: "test-token"}, runtimeProvider, registry)
+	_, registry := testProviders(t, sessionMgr, claudeMgr, codexMgr)
+	srv := NewServer(config.APIConfig{Port: 0, Token: "test-token"}, "claude", registry)
 	srv.uploadDir = t.TempDir()
 
 	mux := http.NewServeMux()
@@ -50,6 +50,13 @@ func setupTestServerWithManagers(t *testing.T, sessionMgr *session.Manager, clau
 	mux.HandleFunc("POST /api/sessions", srv.handleCreateSession)
 	mux.HandleFunc("DELETE /api/sessions/{id}", srv.handleDeleteSession)
 	mux.HandleFunc("POST /api/sessions/{id}/restart", srv.handleRestartSession)
+	mux.HandleFunc("GET /api/runtime/providers", srv.handleListRuntimeProviderMetadata)
+	mux.HandleFunc("GET /api/runtime/{provider}/sessions", srv.handleListProviderRuntimeSessions)
+	mux.HandleFunc("POST /api/runtime/{provider}/sessions", srv.handleCreateProviderRuntimeSession)
+	mux.HandleFunc("DELETE /api/runtime/{provider}/sessions/{id}", srv.handleDeleteProviderRuntimeSession)
+	mux.HandleFunc("POST /api/runtime/{provider}/sessions/{id}/restart", srv.handleRestartProviderRuntimeSession)
+	mux.HandleFunc("GET /api/runtime/{provider}/sessions/{id}/logs", srv.handleProviderRuntimeSessionLogs)
+	mux.HandleFunc("GET /api/runtime/{provider}/folders", srv.handleListProviderFolders)
 	mux.HandleFunc("GET /api/folders", srv.handleListFolders)
 
 	// Generic Chat Provider API
@@ -100,6 +107,16 @@ func testProviders(t *testing.T, sessionMgr *session.Manager, claudeMgr *claudec
 	}
 
 	return runtimeProvider, registry
+}
+
+func requireDefaultRuntimeProvider(t *testing.T, srv *Server) provider.RuntimeProvider {
+	t.Helper()
+
+	runtimeProvider, ok := srv.defaultRuntimeProvider()
+	if !ok {
+		t.Fatal("expected default runtime provider")
+	}
+	return runtimeProvider
 }
 
 type testRunner struct{}
@@ -299,10 +316,65 @@ func TestListSessions_Empty(t *testing.T) {
 	}
 }
 
+func TestListProviderRuntimeSessions_Empty(t *testing.T) {
+	_, mux := setupTestServer(t)
+
+	req := httptest.NewRequest("GET", "/api/runtime/claude/sessions", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var sessions []sessionResponse
+	if err := json.NewDecoder(rr.Body).Decode(&sessions); err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 0 {
+		t.Fatalf("expected 0 sessions, got %d", len(sessions))
+	}
+}
+
+func TestListRuntimeProviderMetadata_ReturnsRuntimeProviders(t *testing.T) {
+	_, mux := setupTestServer(t)
+
+	req := httptest.NewRequest("GET", "/api/runtime/providers", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var providers []providerMetadataResponse
+	if err := json.NewDecoder(rr.Body).Decode(&providers); err != nil {
+		t.Fatal(err)
+	}
+	if len(providers) != 1 {
+		t.Fatalf("expected 1 runtime provider, got %d", len(providers))
+	}
+	if providers[0].ID != "claude" || providers[0].Runtime == nil {
+		t.Fatalf("runtime provider payload = %#v", providers[0])
+	}
+}
+
 func TestListFolders(t *testing.T) {
 	_, mux := setupTestServer(t)
 
 	req := httptest.NewRequest("GET", "/api/folders", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestListProviderFolders(t *testing.T) {
+	_, mux := setupTestServer(t)
+
+	req := httptest.NewRequest("GET", "/api/runtime/claude/folders", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
 
@@ -419,8 +491,9 @@ func TestCreateSession_ResponseIncludesProvider(t *testing.T) {
 		t.Fatalf("runtime provider metadata = %#v", resp.ProviderMeta)
 	}
 
-	if err := srv.runtimeProvider.DeleteSession(resp.ID); err == nil {
-		waitForRuntimeSessionStopped(t, srv.runtimeProvider, resp.ID)
+	runtimeProvider := requireDefaultRuntimeProvider(t, srv)
+	if err := runtimeProvider.DeleteSession(resp.ID); err == nil {
+		waitForRuntimeSessionStopped(t, runtimeProvider, resp.ID)
 	}
 }
 
@@ -759,20 +832,21 @@ func TestSendCodexMessage_NotFoundReturns404(t *testing.T) {
 
 func TestCreateSession_AlreadyRunningReturns409(t *testing.T) {
 	srv, mux := setupTestServer(t)
+	runtimeProvider := requireDefaultRuntimeProvider(t, srv)
 
-	projectDir := filepath.Join(srv.runtimeProvider.BaseFolder(), "demo")
+	projectDir := filepath.Join(runtimeProvider.BaseFolder(), "demo")
 	if err := os.MkdirAll(filepath.Join(projectDir, ".git"), 0755); err != nil {
 		t.Fatalf("MkdirAll(.git): %v", err)
 	}
 
-	sess, err := srv.runtimeProvider.CreateSession("demo")
+	sess, err := runtimeProvider.CreateSession("demo")
 	if err != nil {
 		t.Fatalf("Start(): %v", err)
 	}
 	t.Cleanup(func() {
 		sessionID := sess.Snapshot().ID
-		if err := srv.runtimeProvider.DeleteSession(sessionID); err == nil {
-			waitForRuntimeSessionStopped(t, srv.runtimeProvider, sessionID)
+		if err := runtimeProvider.DeleteSession(sessionID); err == nil {
+			waitForRuntimeSessionStopped(t, runtimeProvider, sessionID)
 		}
 	})
 
@@ -788,21 +862,22 @@ func TestCreateSession_AlreadyRunningReturns409(t *testing.T) {
 
 func TestDeleteSession_NotRunningReturns409(t *testing.T) {
 	srv, mux := setupTestServer(t)
+	runtimeProvider := requireDefaultRuntimeProvider(t, srv)
 
-	projectDir := filepath.Join(srv.runtimeProvider.BaseFolder(), "demo")
+	projectDir := filepath.Join(runtimeProvider.BaseFolder(), "demo")
 	if err := os.MkdirAll(filepath.Join(projectDir, ".git"), 0755); err != nil {
 		t.Fatalf("MkdirAll(.git): %v", err)
 	}
 
-	sess, err := srv.runtimeProvider.CreateSession("demo")
+	sess, err := runtimeProvider.CreateSession("demo")
 	if err != nil {
 		t.Fatalf("Start(): %v", err)
 	}
 	sessionID := sess.Snapshot().ID
-	if err := srv.runtimeProvider.DeleteSession(sessionID); err != nil {
+	if err := runtimeProvider.DeleteSession(sessionID); err != nil {
 		t.Fatalf("Kill(): %v", err)
 	}
-	waitForRuntimeSessionStopped(t, srv.runtimeProvider, sessionID)
+	waitForRuntimeSessionStopped(t, runtimeProvider, sessionID)
 
 	req := httptest.NewRequest("DELETE", "/api/sessions/"+sessionID, nil)
 	rr := httptest.NewRecorder()
@@ -831,9 +906,9 @@ func TestWebSocket_Connect(t *testing.T) {
 	claudeMgr := claudechat.NewManager(t.TempDir(), "")
 	codexMgr := codex.NewManager(t.TempDir(), "")
 
-	runtimeProvider, registry := testProviders(t, sessionMgr, claudeMgr, codexMgr)
-	srv := NewServer(config.APIConfig{}, runtimeProvider, registry)
-	srv.hub.start(runtimeProvider, registry)
+	_, registry := testProviders(t, sessionMgr, claudeMgr, codexMgr)
+	srv := NewServer(config.APIConfig{}, "claude", registry)
+	srv.hub.start(registry)
 	defer srv.hub.stop()
 
 	mux := http.NewServeMux()
@@ -856,9 +931,9 @@ func TestWebSocket_RejectsCrossOrigin(t *testing.T) {
 	claudeMgr := claudechat.NewManager(t.TempDir(), "")
 	codexMgr := codex.NewManager(t.TempDir(), "")
 
-	runtimeProvider, registry := testProviders(t, sessionMgr, claudeMgr, codexMgr)
-	srv := NewServer(config.APIConfig{}, runtimeProvider, registry)
-	srv.hub.start(runtimeProvider, registry)
+	_, registry := testProviders(t, sessionMgr, claudeMgr, codexMgr)
+	srv := NewServer(config.APIConfig{}, "claude", registry)
+	srv.hub.start(registry)
 	defer srv.hub.stop()
 
 	mux := http.NewServeMux()
@@ -949,7 +1024,8 @@ func TestHubHandleChatEvent_EmbedsProviderInSessionPayload(t *testing.T) {
 }
 
 func TestSubscribeClientToSession_LogPayloadIncludesProvider(t *testing.T) {
-	srv := NewServer(config.APIConfig{}, stubRuntimeProvider{
+	registry := provider.NewRegistry()
+	runtimeProvider := stubRuntimeProvider{
 		metadata: provider.Metadata{
 			ID:          "claude",
 			DisplayName: "Claude",
@@ -963,7 +1039,12 @@ func TestSubscribeClientToSession_LogPayloadIncludesProvider(t *testing.T) {
 				logs:     []string{"line one"},
 			},
 		},
-	}, provider.NewRegistry())
+	}
+	if err := registry.RegisterRuntime(runtimeProvider); err != nil {
+		t.Fatalf("RegisterRuntime(): %v", err)
+	}
+
+	srv := NewServer(config.APIConfig{}, "claude", registry)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/httpapi/ws.go
+++ b/internal/httpapi/ws.go
@@ -24,7 +24,7 @@ type wsClient struct {
 type Hub struct {
 	mu           sync.Mutex
 	clients      map[*wsClient]bool
-	unsubSession func()
+	unsubRuntime []func()
 	unsubChat    []func()
 }
 
@@ -34,11 +34,15 @@ func newHub() *Hub {
 	}
 }
 
-func (h *Hub) start(runtimeProvider provider.RuntimeProvider, registry *provider.Registry) {
-	if runtimeProvider != nil {
+func (h *Hub) start(registry *provider.Registry) {
+	if registry == nil {
+		return
+	}
+
+	for _, runtimeProvider := range registry.RuntimeProviders() {
 		metadata := runtimeProvider.Metadata()
 		providerMeta := toProviderMetadataResponse(metadata)
-		h.unsubSession = runtimeProvider.Subscribe(func(notification provider.RuntimeNotification) {
+		unsub := runtimeProvider.Subscribe(func(notification provider.RuntimeNotification) {
 			h.broadcast(wsMessage{
 				Type:         "notification",
 				Provider:     notification.Provider,
@@ -46,10 +50,7 @@ func (h *Hub) start(runtimeProvider provider.RuntimeProvider, registry *provider
 				Line:         notification.Message,
 			})
 		})
-	}
-
-	if registry == nil {
-		return
+		h.unsubRuntime = append(h.unsubRuntime, unsub)
 	}
 
 	for _, p := range registry.ChatProviders() {
@@ -123,8 +124,8 @@ func (h *Hub) handleChatEvent(metadata provider.Metadata, e chat.Event) {
 }
 
 func (h *Hub) stop() {
-	if h.unsubSession != nil {
-		h.unsubSession()
+	for _, unsub := range h.unsubRuntime {
+		unsub()
 	}
 	for _, unsub := range h.unsubChat {
 		unsub()
@@ -244,17 +245,12 @@ func (s *Server) wsReader(c *wsClient) {
 }
 
 func (s *Server) subscribeClientToSession(c *wsClient, sessionID string) {
-	if s.runtimeProvider == nil {
-		return
-	}
-	runtimeMetadata := s.runtimeProvider.Metadata()
-	runtimeProviderID := runtimeMetadata.ID
-	runtimeProviderMeta := toProviderMetadataResponse(runtimeMetadata)
-
-	sess, ok := s.runtimeProvider.GetSession(sessionID)
+	_, metadata, sess, ok := s.findRuntimeSession(sessionID)
 	if !ok {
 		return
 	}
+	runtimeProviderID := metadata.ID
+	runtimeProviderMeta := toProviderMetadataResponse(metadata)
 
 	// Take the snapshot before subscribing so we don't duplicate lines that land
 	// between the backfill and live-stream boundaries.


### PR DESCRIPTION
## Summary
- move runtime HTTP/WebSocket handling onto the provider registry while keeping the legacy `/api/sessions` flow as a default-provider compatibility alias
- add provider-specific config resolution for `claude.runtime`, `claude.chat`, and `codex.chat`, with legacy `rc.*` settings kept as fallback
- update onboarding, config docs, and tests to reflect the new provider-driven runtime model

Closes #21

## Verification
- npm test
- npm run build
- go test ./...
- go vet ./...
- go build -o /tmp/rcod ./cmd/rcodbot