### PR TITLE
feat: add support for gemini-cli chat provider

### DIFF
--- a/app/src/components/AgentBadge.tsx
+++ b/app/src/components/AgentBadge.tsx
@@ -1,6 +1,7 @@
 const styles: Record<string, string> = {
   claude: "border border-accent-blue/20 bg-accent-blue/10 text-accent-blue",
   codex: "border border-accent-orange/20 bg-accent-orange/10 text-accent-orange",
+  gemini: "border border-accent-green/20 bg-accent-green/10 text-accent-green",
 };
 
 export function AgentBadge({ agent, label }: { agent: string; label?: string }) {

--- a/app/src/components/ChatCard.tsx
+++ b/app/src/components/ChatCard.tsx
@@ -1,10 +1,10 @@
-import type { CodexSession, DraftAttachment } from "../api/types";
+import type { ChatSession, DraftAttachment } from "../api/types";
 import { StatusDot } from "./StatusDot";
 import { AgentBadge } from "./AgentBadge";
 import { MessageInput } from "./MessageInput";
 
 interface Props {
-  session: CodexSession;
+  session: ChatSession;
   busy: boolean;
   expanded: boolean;
   onToggle: () => void;
@@ -13,7 +13,7 @@ interface Props {
   onClose: (id: string) => void | Promise<void>;
 }
 
-export function CodexChatCard({
+export function ChatCard({
   session,
   busy,
   expanded,
@@ -24,6 +24,7 @@ export function CodexChatCard({
 }: Props) {
   const messages = session.messages || [];
   const visibleMessages = expanded ? messages : messages.slice(-2);
+  const agentName = session.agent.charAt(0).toUpperCase() + session.agent.slice(1);
 
   return (
     <div
@@ -40,7 +41,7 @@ export function CodexChatCard({
           <span className="font-medium text-sm truncate">{session.rel_name}</span>
         </div>
         <div className="flex items-center gap-2 shrink-0">
-          <AgentBadge agent="codex" />
+          <AgentBadge agent={session.agent as any} />
           <span className="text-xs text-text-muted">
             {messages.length} msg{messages.length !== 1 ? "s" : ""}
           </span>
@@ -79,7 +80,7 @@ export function CodexChatCard({
             onSendPrompt={(msg, attachments) => onSend(session.id, msg, attachments)}
             onSendCommand={onRunCommand ? (command) => onRunCommand(session.id, command) : undefined}
             disabled={busy}
-            promptPlaceholder={busy ? "Codex is thinking..." : "Send a message to Codex..."}
+            promptPlaceholder={busy ? `${agentName} is thinking...` : `Send a message to ${agentName}...`}
             commandPlaceholder={busy ? "Command is running..." : "Run a bash command..."}
             supportsImages
             supportsBash={Boolean(onRunCommand)}

--- a/app/src/components/ChatCard.tsx
+++ b/app/src/components/ChatCard.tsx
@@ -25,6 +25,7 @@ export function ChatCard({
   const messages = session.messages || [];
   const visibleMessages = expanded ? messages : messages.slice(-2);
   const agentName = session.agent.charAt(0).toUpperCase() + session.agent.slice(1);
+  const supportsImages = session.provider_meta?.chat?.image_attachments ?? false;
 
   return (
     <div
@@ -82,7 +83,7 @@ export function ChatCard({
             disabled={busy}
             promptPlaceholder={busy ? `${agentName} is thinking...` : `Send a message to ${agentName}...`}
             commandPlaceholder={busy ? "Command is running..." : "Run a bash command..."}
-            supportsImages
+            supportsImages={supportsImages}
             supportsBash={Boolean(onRunCommand)}
           />
           <button

--- a/app/src/components/PanelLayout.tsx
+++ b/app/src/components/PanelLayout.tsx
@@ -99,7 +99,7 @@ export function PanelLayout({
             providerID={providerID}
             providers={providers}
             session={focusedSession}
-            streamBlocks={state.streamBlocks[focusedSession.id] || []}
+            streamBlocks={state.streamBlocks[`${providerID}:${focusedSession.id}`] || []}
             onClose={onClearFocus}
             onSend={(id, msg, att) => actions.sendChatMessage(providerID, id, msg, att)}
             onRunCommand={(id, cmd) => actions.runChatCommand(providerID, id, cmd)}
@@ -171,7 +171,7 @@ export function PanelLayout({
                   slot.session
                     ? buildSessionPreview(
                         slot.session,
-                        state.streamBlocks[slot.session.id] || [],
+                        state.streamBlocks[`${getSessionProviderID(slot.session)}:${slot.session.id}`] || [],
                         getPreviewLineCount(density)
                       )
                     : []

--- a/app/src/components/SessionGrid.tsx
+++ b/app/src/components/SessionGrid.tsx
@@ -10,8 +10,8 @@ interface Props {
   chatBusy: Record<string, boolean>;
   onKill: (id: string) => void;
   onRestart: (id: string) => void;
-  onChatSend: (id: string, message: string, attachments?: DraftAttachment[]) => void | Promise<void>;
-  onChatClose: (id: string) => void | Promise<void>;
+  onChatSend: (provider: string, id: string, message: string, attachments?: DraftAttachment[]) => void | Promise<void>;
+  onChatClose: (provider: string, id: string) => void | Promise<void>;
 }
 
 export function SessionGrid({
@@ -55,11 +55,11 @@ export function SessionGrid({
         <ChatCard
           key={`${s.agent}:${s.id}`}
           session={s}
-          busy={chatBusy[s.id] || false}
+          busy={chatBusy[`${s.agent}:${s.id}`] || false}
           expanded={expandedId === `${s.agent}:${s.id}`}
           onToggle={() => toggle(`${s.agent}:${s.id}`)}
-          onSend={onChatSend}
-          onClose={onChatClose}
+          onSend={(id, msg, att) => onChatSend(s.agent, id, msg, att)}
+          onClose={(id) => onChatClose(s.agent, id)}
         />
       ))}
     </div>

--- a/app/src/components/SessionGrid.tsx
+++ b/app/src/components/SessionGrid.tsx
@@ -1,28 +1,28 @@
 import { useState } from "react";
-import type { DraftAttachment, Session, CodexSession } from "../api/types";
+import type { DraftAttachment, Session, ChatSession } from "../api/types";
 import { SessionCard } from "./SessionCard";
-import { CodexChatCard } from "./CodexChatCard";
+import { ChatCard } from "./ChatCard";
 
 interface Props {
   sessions: Session[];
-  codexSessions: CodexSession[];
+  chatSessions: ChatSession[];
   logs: Record<string, string[]>;
-  codexBusy: Record<string, boolean>;
+  chatBusy: Record<string, boolean>;
   onKill: (id: string) => void;
   onRestart: (id: string) => void;
-  onCodexSend: (id: string, message: string, attachments?: DraftAttachment[]) => void | Promise<void>;
-  onCodexClose: (id: string) => void | Promise<void>;
+  onChatSend: (id: string, message: string, attachments?: DraftAttachment[]) => void | Promise<void>;
+  onChatClose: (id: string) => void | Promise<void>;
 }
 
 export function SessionGrid({
   sessions,
-  codexSessions,
+  chatSessions,
   logs,
-  codexBusy,
+  chatBusy,
   onKill,
   onRestart,
-  onCodexSend,
-  onCodexClose,
+  onChatSend,
+  onChatClose,
 }: Props) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
@@ -30,7 +30,7 @@ export function SessionGrid({
     setExpandedId((prev) => (prev === id ? null : id));
   };
 
-  if (sessions.length === 0 && codexSessions.length === 0) {
+  if (sessions.length === 0 && chatSessions.length === 0) {
     return (
       <div className="flex items-center justify-center h-64 text-text-muted text-sm">
         No sessions yet. Create one to get started.
@@ -51,15 +51,15 @@ export function SessionGrid({
           onRestart={onRestart}
         />
       ))}
-      {codexSessions.map((s) => (
-        <CodexChatCard
+      {chatSessions.map((s) => (
+        <ChatCard
           key={s.id}
           session={s}
-          busy={codexBusy[s.id] || false}
+          busy={chatBusy[s.id] || false}
           expanded={expandedId === s.id}
           onToggle={() => toggle(s.id)}
-          onSend={onCodexSend}
-          onClose={onCodexClose}
+          onSend={onChatSend}
+          onClose={onChatClose}
         />
       ))}
     </div>

--- a/app/src/components/SessionGrid.tsx
+++ b/app/src/components/SessionGrid.tsx
@@ -53,11 +53,11 @@ export function SessionGrid({
       ))}
       {chatSessions.map((s) => (
         <ChatCard
-          key={s.id}
+          key={`${s.agent}:${s.id}`}
           session={s}
           busy={chatBusy[s.id] || false}
-          expanded={expandedId === s.id}
-          onToggle={() => toggle(s.id)}
+          expanded={expandedId === `${s.agent}:${s.id}`}
+          onToggle={() => toggle(`${s.agent}:${s.id}`)}
           onSend={onChatSend}
           onClose={onChatClose}
         />

--- a/app/src/hooks/useSessions.ts
+++ b/app/src/hooks/useSessions.ts
@@ -535,13 +535,13 @@ export function useSessionsReducer() {
     });
 
     const unsubToolDelta = onMessage("chat_tool_delta", (msg: WsMessage) => {
-      if (msg.session_id && msg.provider && msg.tool_call && msg.delta) {
+      if (msg.session_id && msg.provider && msg.tool_call && msg.tool_call.partial_json) {
         dispatch({
           type: "TOOL_DELTA",
           provider: msg.provider,
           sessionId: msg.session_id,
           index: msg.tool_call.index,
-          partialJSON: msg.delta,
+          partialJSON: msg.tool_call.partial_json,
         });
       }
     });
@@ -583,7 +583,8 @@ export function useSessionsReducer() {
       dispatch({ type: "REMOVE_SESSION", sessionId: id });
     },
     restartSession: async (id: string) => {
-      await api.post(`/api/sessions/${id}/restart`);
+      const session = await api.post<Session>(`/api/sessions/${id}/restart`);
+      dispatch({ type: "UPDATE_SESSION", session });
     },
     createChatSession: async (provider: string, folder: string) => {
       const session = await api.post<ChatSession>(`/api/chat/${provider}/sessions`, { folder });

--- a/app/src/hooks/useSessions.ts
+++ b/app/src/hooks/useSessions.ts
@@ -120,7 +120,12 @@ export function reduceSessionsState(state: State, action: Action): State {
         streamBlocks: omitKey(state.streamBlocks, `${action.provider}:${action.sessionId}`),
       };
     case "ADD_CHAT_MESSAGE": {
-      const enrichedMessage = { ...action.message, timestamp: action.message.timestamp || new Date().toISOString() };
+      const key = `${action.provider}:${action.sessionId}`;
+      const enrichedMessage = {
+        ...action.message,
+        timestamp: action.message.timestamp || new Date().toISOString(),
+        blocks: action.message.role === "assistant" ? state.streamBlocks[key] : undefined,
+      };
       return {
         ...state,
         chatSessions: {
@@ -138,7 +143,7 @@ export function reduceSessionsState(state: State, action: Action): State {
               : s
           ),
         },
-        streamBlocks: omitKey(state.streamBlocks, `${action.provider}:${action.sessionId}`),
+        streamBlocks: omitKey(state.streamBlocks, key),
       };
     }
     case "REMOVE_OPTIMISTIC_MESSAGE":
@@ -586,11 +591,10 @@ export function useSessionsReducer() {
       return session;
     },
     loadAdoptableChatSessions: async (provider: string) => {
-      const resp = await api.get<{ sessions: AdoptableSession[] }>(`/api/chat/${provider}/adoptable`);
-      return resp.sessions;
+      return await api.get<AdoptableSession[]>(`/api/chat/${provider}/adoptable`);
     },
-    adoptChatSession: async (provider: string, threadID: string) => {
-      const session = await api.post<ChatSession>(`/api/chat/${provider}/adopt`, { threadID });
+    adoptChatSession: async (provider: string, thread_id: string) => {
+      const session = await api.post<ChatSession>(`/api/chat/${provider}/adopt`, { thread_id });
       dispatch({ type: "ADD_CHAT_SESSION", provider, session });
       return session;
     },

--- a/app/src/hooks/useSessions.ts
+++ b/app/src/hooks/useSessions.ts
@@ -27,7 +27,7 @@ interface State {
   sessions: Session[];
   chatSessions: Record<string, ChatSession[]>; // provider -> sessions
   logs: Record<string, string[]>;
-  streamBlocks: Record<string, StreamBlock[]>;
+  streamBlocks: Record<string, StreamBlock[]>; // provider:id -> blocks
   loading: boolean;
   authRequired: boolean;
   loadError: string | null;
@@ -54,16 +54,16 @@ type Action =
   | { type: "REMOVE_CHAT_SESSION"; provider: string; sessionId: string }
   | { type: "ADD_CHAT_MESSAGE"; provider: string; sessionId: string; message: Message }
   | { type: "REMOVE_OPTIMISTIC_MESSAGE"; provider: string; sessionId: string; optimisticId: string }
-  | { type: "APPEND_STREAMING"; sessionId: string; delta: string }
-  | { type: "CLEAR_STREAMING"; sessionId: string }
+  | { type: "APPEND_STREAMING"; provider: string; sessionId: string; delta: string }
+  | { type: "CLEAR_STREAMING"; provider: string; sessionId: string }
   | { type: "SET_CHAT_BUSY"; provider: string; sessionId: string; busy: boolean }
   | { type: "SET_LOADING"; loading: boolean }
   | { type: "SET_AUTH_REQUIRED"; authRequired: boolean }
   | { type: "SET_LOAD_ERROR"; error: string | null }
   | { type: "RECONCILE_ON_RECONNECT" }
-  | { type: "TOOL_START"; sessionId: string; index: number; id: string; name: string }
-  | { type: "TOOL_DELTA"; sessionId: string; index: number; partialJSON: string }
-  | { type: "TOOL_FINISH"; sessionId: string; index: number };
+  | { type: "TOOL_START"; provider: string; sessionId: string; index: number; id: string; name: string }
+  | { type: "TOOL_DELTA"; provider: string; sessionId: string; index: number; partialJSON: string }
+  | { type: "TOOL_FINISH"; provider: string; sessionId: string; index: number };
 
 const MAX_LOG_LINES = 100;
 
@@ -117,14 +117,10 @@ export function reduceSessionsState(state: State, action: Action): State {
           ...state.chatSessions,
           [action.provider]: (state.chatSessions[action.provider] || []).filter((s) => s.id !== action.sessionId),
         },
-        streamBlocks: omitKey(state.streamBlocks, action.sessionId),
+        streamBlocks: omitKey(state.streamBlocks, `${action.provider}:${action.sessionId}`),
       };
     case "ADD_CHAT_MESSAGE": {
-      const currentBlocks = state.streamBlocks[action.sessionId] || [];
-      const enrichedMessage =
-        action.message.role === "assistant" && currentBlocks.length > 0
-          ? { ...action.message, blocks: [...currentBlocks] }
-          : action.message;
+      const enrichedMessage = { ...action.message, timestamp: action.message.timestamp || new Date().toISOString() };
       return {
         ...state,
         chatSessions: {
@@ -142,7 +138,7 @@ export function reduceSessionsState(state: State, action: Action): State {
               : s
           ),
         },
-        streamBlocks: omitKey(state.streamBlocks, action.sessionId),
+        streamBlocks: omitKey(state.streamBlocks, `${action.provider}:${action.sessionId}`),
       };
     }
     case "REMOVE_OPTIMISTIC_MESSAGE":
@@ -161,17 +157,18 @@ export function reduceSessionsState(state: State, action: Action): State {
         },
       };
     case "APPEND_STREAMING": {
-      const blocks = [...(state.streamBlocks[action.sessionId] || [])];
+      const key = `${action.provider}:${action.sessionId}`;
+      const blocks = [...(state.streamBlocks[key] || [])];
       const last = blocks[blocks.length - 1];
       if (last && last.type === "text") {
         blocks[blocks.length - 1] = { ...last, content: last.content + action.delta };
       } else {
         blocks.push({ type: "text", content: action.delta });
       }
-      return { ...state, streamBlocks: { ...state.streamBlocks, [action.sessionId]: blocks } };
+      return { ...state, streamBlocks: { ...state.streamBlocks, [key]: blocks } };
     }
     case "CLEAR_STREAMING":
-      return { ...state, streamBlocks: omitKey(state.streamBlocks, action.sessionId) };
+      return { ...state, streamBlocks: omitKey(state.streamBlocks, `${action.provider}:${action.sessionId}`) };
     case "SET_CHAT_BUSY":
       return {
         ...state,
@@ -181,7 +178,7 @@ export function reduceSessionsState(state: State, action: Action): State {
             s.id === action.sessionId ? { ...s, busy: action.busy } : s
           ),
         },
-        streamBlocks: action.busy ? state.streamBlocks : omitKey(state.streamBlocks, action.sessionId),
+        streamBlocks: action.busy ? state.streamBlocks : omitKey(state.streamBlocks, `${action.provider}:${action.sessionId}`),
       };
     case "SET_LOADING":
       return { ...state, loading: action.loading };
@@ -192,7 +189,8 @@ export function reduceSessionsState(state: State, action: Action): State {
     case "RECONCILE_ON_RECONNECT":
       return { ...state, streamBlocks: {} };
     case "TOOL_START": {
-      const blocks = [...(state.streamBlocks[action.sessionId] || [])];
+      const key = `${action.provider}:${action.sessionId}`;
+      const blocks = [...(state.streamBlocks[key] || [])];
       blocks.push({
         type: "tool_use",
         index: action.index,
@@ -201,21 +199,23 @@ export function reduceSessionsState(state: State, action: Action): State {
         inputJSON: "",
         done: false,
       });
-      return { ...state, streamBlocks: { ...state.streamBlocks, [action.sessionId]: blocks } };
+      return { ...state, streamBlocks: { ...state.streamBlocks, [key]: blocks } };
     }
     case "TOOL_DELTA": {
-      const blocks = (state.streamBlocks[action.sessionId] || []).map((b) =>
+      const key = `${action.provider}:${action.sessionId}`;
+      const blocks = (state.streamBlocks[key] || []).map((b) =>
         b.type === "tool_use" && b.index === action.index
           ? { ...b, inputJSON: b.inputJSON + action.partialJSON }
           : b
       );
-      return { ...state, streamBlocks: { ...state.streamBlocks, [action.sessionId]: blocks } };
+      return { ...state, streamBlocks: { ...state.streamBlocks, [key]: blocks } };
     }
     case "TOOL_FINISH": {
-      const blocks = (state.streamBlocks[action.sessionId] || []).map((b) =>
+      const key = `${action.provider}:${action.sessionId}`;
+      const blocks = (state.streamBlocks[key] || []).map((b) =>
         b.type === "tool_use" && b.index === action.index ? { ...b, done: true } : b
       );
-      return { ...state, streamBlocks: { ...state.streamBlocks, [action.sessionId]: blocks } };
+      return { ...state, streamBlocks: { ...state.streamBlocks, [key]: blocks } };
     }
     default:
       return state;
@@ -499,8 +499,8 @@ export function useSessionsReducer() {
     });
 
     const unsubChatDelta = onMessage("chat_message_delta", (msg: WsMessage) => {
-      if (msg.session_id && msg.delta) {
-        dispatch({ type: "APPEND_STREAMING", sessionId: msg.session_id, delta: msg.delta });
+      if (msg.session_id && msg.delta && msg.provider) {
+        dispatch({ type: "APPEND_STREAMING", provider: msg.provider, sessionId: msg.session_id, delta: msg.delta });
       }
     });
 
@@ -517,9 +517,10 @@ export function useSessionsReducer() {
     });
 
     const unsubToolStart = onMessage("chat_tool_start", (msg: WsMessage) => {
-      if (msg.session_id && msg.tool_call) {
+      if (msg.session_id && msg.provider && msg.tool_call) {
         dispatch({
           type: "TOOL_START",
+          provider: msg.provider,
           sessionId: msg.session_id,
           index: msg.tool_call.index,
           id: msg.tool_call.id || "",
@@ -529,20 +530,22 @@ export function useSessionsReducer() {
     });
 
     const unsubToolDelta = onMessage("chat_tool_delta", (msg: WsMessage) => {
-      if (msg.session_id && msg.tool_call) {
+      if (msg.session_id && msg.provider && msg.tool_call && msg.delta) {
         dispatch({
           type: "TOOL_DELTA",
+          provider: msg.provider,
           sessionId: msg.session_id,
           index: msg.tool_call.index,
-          partialJSON: msg.tool_call.partial_json || "",
+          partialJSON: msg.delta,
         });
       }
     });
 
     const unsubToolFinish = onMessage("chat_tool_finish", (msg: WsMessage) => {
-      if (msg.session_id && msg.tool_call) {
+      if (msg.session_id && msg.provider && msg.tool_call) {
         dispatch({
           type: "TOOL_FINISH",
+          provider: msg.provider,
           sessionId: msg.session_id,
           index: msg.tool_call.index,
         });
@@ -566,35 +569,30 @@ export function useSessionsReducer() {
 
   const actions: Actions = {
     startSession: async (folder: string) => {
-      const sess = await api.post<Session>("/api/sessions", { folder });
-      dispatch({ type: "ADD_SESSION", session: sess });
-      return sess;
+      const session = await api.post<Session>("/api/sessions", { folder });
+      dispatch({ type: "ADD_SESSION", session });
+      return session;
     },
     killSession: async (id: string) => {
-      await api.del(`/api/sessions/${id}`);
-      dispatch({
-        type: "UPDATE_STATUS",
-        sessionId: id,
-        status: "stopped",
-        restarts: 0,
-      });
+      await api.post(`/api/sessions/${id}/kill`);
+      dispatch({ type: "REMOVE_SESSION", sessionId: id });
     },
     restartSession: async (id: string) => {
-      const sess = await api.post<Session>(`/api/sessions/${id}/restart`);
-      dispatch({ type: "UPDATE_SESSION", session: sess });
+      await api.post(`/api/sessions/${id}/restart`);
     },
     createChatSession: async (provider: string, folder: string) => {
-      const sess = await api.post<ChatSession>(`/api/chat/${provider}/sessions`, { folder });
-      dispatch({ type: "ADD_CHAT_SESSION", provider, session: sess });
-      return sess;
+      const session = await api.post<ChatSession>(`/api/chat/${provider}/sessions`, { folder });
+      dispatch({ type: "ADD_CHAT_SESSION", provider, session });
+      return session;
     },
     loadAdoptableChatSessions: async (provider: string) => {
-      return api.get<AdoptableSession[]>(`/api/chat/${provider}/adoptable`);
+      const resp = await api.get<{ sessions: AdoptableSession[] }>(`/api/chat/${provider}/adoptable`);
+      return resp.sessions;
     },
     adoptChatSession: async (provider: string, threadID: string) => {
-      const sess = await api.post<ChatSession>(`/api/chat/${provider}/adopt`, { thread_id: threadID });
-      dispatch({ type: "ADD_CHAT_SESSION", provider, session: sess });
-      return sess;
+      const session = await api.post<ChatSession>(`/api/chat/${provider}/adopt`, { threadID });
+      dispatch({ type: "ADD_CHAT_SESSION", provider, session });
+      return session;
     },
     closeChatSession: async (provider: string, id: string) => {
       await api.del(`/api/chat/${provider}/sessions/${id}`);
@@ -604,7 +602,7 @@ export function useSessionsReducer() {
       const timestamp = new Date().toISOString();
       const optimisticId = createOptimisticMessageId();
       dispatch({ type: "SET_CHAT_BUSY", provider, sessionId: id, busy: true });
-      dispatch({ type: "CLEAR_STREAMING", sessionId: id });
+      dispatch({ type: "CLEAR_STREAMING", provider, sessionId: id });
       dispatch({
         type: "ADD_CHAT_MESSAGE",
         provider,
@@ -636,7 +634,7 @@ export function useSessionsReducer() {
       const timestamp = new Date().toISOString();
       const optimisticId = createOptimisticMessageId();
       dispatch({ type: "SET_CHAT_BUSY", provider, sessionId: id, busy: true });
-      dispatch({ type: "CLEAR_STREAMING", sessionId: id });
+      dispatch({ type: "CLEAR_STREAMING", provider, sessionId: id });
       dispatch({
         type: "ADD_CHAT_MESSAGE",
         provider,

--- a/app/src/hooks/useSessions.ts
+++ b/app/src/hooks/useSessions.ts
@@ -121,10 +121,13 @@ export function reduceSessionsState(state: State, action: Action): State {
       };
     case "ADD_CHAT_MESSAGE": {
       const key = `${action.provider}:${action.sessionId}`;
+      const currentBlocks = state.streamBlocks[key] || [];
       const enrichedMessage = {
         ...action.message,
         timestamp: action.message.timestamp || new Date().toISOString(),
-        blocks: action.message.role === "assistant" ? state.streamBlocks[key] : undefined,
+        blocks: action.message.role === "assistant"
+          ? (currentBlocks.length > 0 ? currentBlocks : action.message.blocks)
+          : undefined,
       };
       return {
         ...state,

--- a/app/src/hooks/useSessions.ts
+++ b/app/src/hooks/useSessions.ts
@@ -579,7 +579,7 @@ export function useSessionsReducer() {
       return session;
     },
     killSession: async (id: string) => {
-      await api.post(`/api/sessions/${id}/kill`);
+      await api.del(`/api/sessions/${id}`);
       dispatch({ type: "REMOVE_SESSION", sessionId: id });
     },
     restartSession: async (id: string) => {

--- a/cmd/rcodbot/main.go
+++ b/cmd/rcodbot/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zevro-ai/remote-control-on-demand/internal/claudechat"
 	"github.com/zevro-ai/remote-control-on-demand/internal/codex"
 	"github.com/zevro-ai/remote-control-on-demand/internal/config"
+	"github.com/zevro-ai/remote-control-on-demand/internal/gemini"
 	"github.com/zevro-ai/remote-control-on-demand/internal/httpapi"
 	"github.com/zevro-ai/remote-control-on-demand/internal/process"
 	"github.com/zevro-ai/remote-control-on-demand/internal/provider"
@@ -115,9 +116,16 @@ func main() {
 		log.Fatalf("Restoring Claude chat sessions: %v", err)
 	}
 
+	geminiStatePath := runtimepaths.ResolveStatePath(*configPath, *stateDir, "gemini_sessions.json")
+	geminiMgr := gemini.NewManager(cfg.RC.BaseFolder, geminiStatePath)
+	geminiMgr.ConfigurePermissionMode(cfg.GeminiChatPermissionMode())
+	if err := geminiMgr.Restore(); err != nil {
+		log.Fatalf("Restoring Gemini chat sessions: %v", err)
+	}
+
 	var notifier rcodbot.Notifier
 	if cfg.Telegram.Token != "" {
-		bt, err := rcodbot.New(cfg.Telegram.Token, cfg.Telegram.AllowedUserID, sessionMgr, codexMgr)
+		bt, err := rcodbot.New(cfg.Telegram.Token, cfg.Telegram.AllowedUserID, sessionMgr, codexMgr, geminiMgr)
 		if err != nil {
 			log.Fatalf("Creating bot: %v", err)
 		}
@@ -154,6 +162,10 @@ func main() {
 			log.Fatalf("Registering Codex chat provider: %v", err)
 		}
 
+		if err := registry.RegisterChat(geminiMgr); err != nil {
+			log.Fatalf("Registering Gemini chat provider: %v", err)
+		}
+
 		httpSrv = httpapi.NewServer(cfg.API, "claude", registry)
 		go httpSrv.Start()
 	}
@@ -170,6 +182,7 @@ func main() {
 		}
 		claudeMgr.Shutdown()
 		codexMgr.Shutdown()
+		geminiMgr.Shutdown()
 		stopped := sessionMgr.StopAll()
 		notifier.SendMessage(fmt.Sprintf("<b>RCOD bot stopped.</b>\nClosed Claude sessions: <code>%d</code>", stopped))
 		notifier.Stop()

--- a/cmd/rcodbot/main.go
+++ b/cmd/rcodbot/main.go
@@ -117,10 +117,13 @@ func main() {
 	}
 
 	geminiStatePath := runtimepaths.ResolveStatePath(*configPath, *stateDir, "gemini_sessions.json")
-	geminiMgr := gemini.NewManager(cfg.RC.BaseFolder, geminiStatePath)
-	geminiMgr.ConfigurePermissionMode(cfg.GeminiChatPermissionMode())
-	if err := geminiMgr.Restore(); err != nil {
-		log.Fatalf("Restoring Gemini chat sessions: %v", err)
+	var geminiMgr *gemini.Manager
+	if cfg.Providers.Gemini.Enabled {
+		geminiMgr = gemini.NewManager(cfg.RC.BaseFolder, geminiStatePath)
+		geminiMgr.ConfigurePermissionMode(cfg.GeminiChatPermissionMode())
+		if err := geminiMgr.Restore(); err != nil {
+			log.Fatalf("Restoring Gemini chat sessions: %v", err)
+		}
 	}
 
 	var notifier rcodbot.Notifier
@@ -163,8 +166,10 @@ func main() {
 			log.Fatalf("Registering Codex chat provider: %v", err)
 		}
 
-		if err := registry.RegisterChat(geminiMgr); err != nil {
-			log.Fatalf("Registering Gemini chat provider: %v", err)
+		if geminiMgr != nil {
+			if err := registry.RegisterChat(geminiMgr); err != nil {
+				log.Fatalf("Registering Gemini chat provider: %v", err)
+			}
 		}
 
 		httpSrv = httpapi.NewServer(cfg.API, "claude", registry)

--- a/cmd/rcodbot/main.go
+++ b/cmd/rcodbot/main.go
@@ -188,10 +188,13 @@ func main() {
 		}
 		claudeMgr.Shutdown()
 		codexMgr.Shutdown()
-		geminiMgr.Shutdown()
+		if geminiMgr != nil {
+			geminiMgr.Shutdown()
+		}
 		stopped := sessionMgr.StopAll()
 		notifier.SendMessage(fmt.Sprintf("<b>RCOD bot stopped.</b>\nClosed Claude sessions: <code>%d</code>", stopped))
 		notifier.Stop()
+		os.Exit(0)
 	}()
 
 	printBanner()

--- a/cmd/rcodbot/main.go
+++ b/cmd/rcodbot/main.go
@@ -125,7 +125,8 @@ func main() {
 
 	var notifier rcodbot.Notifier
 	if cfg.Telegram.Token != "" {
-		bt, err := rcodbot.New(cfg.Telegram.Token, cfg.Telegram.AllowedUserID, sessionMgr, codexMgr, geminiMgr)
+		botStatePath := runtimepaths.ResolveStatePath(*configPath, *stateDir, "bot_state.json")
+		bt, err := rcodbot.New(cfg.Telegram.Token, cfg.Telegram.AllowedUserID, sessionMgr, codexMgr, geminiMgr, botStatePath)
 		if err != nil {
 			log.Fatalf("Creating bot: %v", err)
 		}

--- a/cmd/rcodbot/main.go
+++ b/cmd/rcodbot/main.go
@@ -194,7 +194,6 @@ func main() {
 		stopped := sessionMgr.StopAll()
 		notifier.SendMessage(fmt.Sprintf("<b>RCOD bot stopped.</b>\nClosed Claude sessions: <code>%d</code>", stopped))
 		notifier.Stop()
-		os.Exit(0)
 	}()
 
 	printBanner()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -57,3 +57,7 @@ providers:
   codex:
     chat:
       permission_mode: "workspace-write"  # use bypassPermissions only for full local access
+
+  gemini:
+    chat:
+      permission_mode: "auto_edit"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -59,5 +59,6 @@ providers:
       permission_mode: "workspace-write"  # use bypassPermissions only for full local access
 
   gemini:
+    enabled: true
     chat:
-      permission_mode: "auto_edit"
+      permission_mode: "auto_edit" # Options: auto_edit, plan, yolo, read-only, workspace-write

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,7 +79,8 @@ type CodexProviderConfig struct {
 }
 
 type GeminiProviderConfig struct {
-	Chat ProviderChatConfig `yaml:"chat,omitempty"`
+	Enabled bool               `yaml:"enabled,omitempty"`
+	Chat    ProviderChatConfig `yaml:"chat,omitempty"`
 }
 
 type ProviderChatConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,6 +107,11 @@ const (
 	PermissionModeReadOnly     = "read-only"
 	PermissionModeWorkspace    = "workspace-write"
 	PermissionModeDangerFull   = "danger-full-access"
+
+	// Gemini CLI specific modes
+	PermissionModeGeminiAutoEdit = "auto_edit"
+	PermissionModeGeminiPlan     = "plan"
+	PermissionModeGeminiYolo     = "yolo"
 )
 
 // ProjectConfig represents per-project settings in .rcod.yaml
@@ -246,10 +251,13 @@ func NormalizeCodexPermissionMode(permissionMode string) string {
 
 func ValidateCodexPermissionMode(permissionMode string) error {
 	switch NormalizeCodexPermissionMode(permissionMode) {
-	case PermissionModeBypass, PermissionModeReadOnly, PermissionModeWorkspace, PermissionModeDangerFull:
+	case PermissionModeBypass, PermissionModeReadOnly, PermissionModeWorkspace, PermissionModeDangerFull,
+		PermissionModeGeminiAutoEdit, PermissionModeGeminiPlan, PermissionModeGeminiYolo:
 		return nil
 	default:
-		return fmt.Errorf("must be one of %q, %q, %q, or %q", PermissionModeBypass, PermissionModeReadOnly, PermissionModeWorkspace, PermissionModeDangerFull)
+		return fmt.Errorf("must be one of %q, %q, %q, %q, %q, %q, or %q",
+			PermissionModeBypass, PermissionModeReadOnly, PermissionModeWorkspace, PermissionModeDangerFull,
+			PermissionModeGeminiAutoEdit, PermissionModeGeminiPlan, PermissionModeGeminiYolo)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -251,6 +251,15 @@ func NormalizeCodexPermissionMode(permissionMode string) string {
 
 func ValidateCodexPermissionMode(permissionMode string) error {
 	switch NormalizeCodexPermissionMode(permissionMode) {
+	case PermissionModeBypass, PermissionModeReadOnly, PermissionModeWorkspace, PermissionModeDangerFull:
+		return nil
+	default:
+		return fmt.Errorf("must be one of %q, %q, %q, or %q", PermissionModeBypass, PermissionModeReadOnly, PermissionModeWorkspace, PermissionModeDangerFull)
+	}
+}
+
+func ValidateGeminiPermissionMode(permissionMode string) error {
+	switch NormalizeCodexPermissionMode(permissionMode) {
 	case PermissionModeBypass, PermissionModeReadOnly, PermissionModeWorkspace, PermissionModeDangerFull,
 		PermissionModeGeminiAutoEdit, PermissionModeGeminiPlan, PermissionModeGeminiYolo:
 		return nil
@@ -344,7 +353,7 @@ func (p ProvidersConfig) Validate() error {
 }
 
 func (p ClaudeProviderConfig) Validate() error {
-	if err := p.Chat.Validate(); err != nil {
+	if err := p.Chat.validateWith(ValidateCodexPermissionMode); err != nil {
 		return fmt.Errorf("chat: %w", err)
 	}
 	if err := p.Runtime.Validate(); err != nil {
@@ -354,24 +363,24 @@ func (p ClaudeProviderConfig) Validate() error {
 }
 
 func (p CodexProviderConfig) Validate() error {
-	if err := p.Chat.Validate(); err != nil {
+	if err := p.Chat.validateWith(ValidateCodexPermissionMode); err != nil {
 		return fmt.Errorf("chat: %w", err)
 	}
 	return nil
 }
 
 func (p GeminiProviderConfig) Validate() error {
-	if err := p.Chat.Validate(); err != nil {
+	if err := p.Chat.validateWith(ValidateGeminiPermissionMode); err != nil {
 		return fmt.Errorf("chat: %w", err)
 	}
 	return nil
 }
 
-func (p ProviderChatConfig) Validate() error {
+func (p ProviderChatConfig) validateWith(validator func(string) error) error {
 	if strings.TrimSpace(p.PermissionMode) == "" {
 		return nil
 	}
-	return ValidateCodexPermissionMode(p.PermissionMode)
+	return validator(p.PermissionMode)
 }
 
 func (p ProviderRuntimeConfig) Validate() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,7 @@ type RCConfig struct {
 type ProvidersConfig struct {
 	Claude ClaudeProviderConfig `yaml:"claude,omitempty"`
 	Codex  CodexProviderConfig  `yaml:"codex,omitempty"`
+	Gemini GeminiProviderConfig `yaml:"gemini,omitempty"`
 }
 
 type ClaudeProviderConfig struct {
@@ -74,6 +75,10 @@ type ClaudeProviderConfig struct {
 }
 
 type CodexProviderConfig struct {
+	Chat ProviderChatConfig `yaml:"chat,omitempty"`
+}
+
+type GeminiProviderConfig struct {
 	Chat ProviderChatConfig `yaml:"chat,omitempty"`
 }
 
@@ -324,6 +329,9 @@ func (p ProvidersConfig) Validate() error {
 	if err := p.Codex.Validate(); err != nil {
 		return fmt.Errorf("codex: %w", err)
 	}
+	if err := p.Gemini.Validate(); err != nil {
+		return fmt.Errorf("gemini: %w", err)
+	}
 	return nil
 }
 
@@ -338,6 +346,13 @@ func (p ClaudeProviderConfig) Validate() error {
 }
 
 func (p CodexProviderConfig) Validate() error {
+	if err := p.Chat.Validate(); err != nil {
+		return fmt.Errorf("chat: %w", err)
+	}
+	return nil
+}
+
+func (p GeminiProviderConfig) Validate() error {
 	if err := p.Chat.Validate(); err != nil {
 		return fmt.Errorf("chat: %w", err)
 	}
@@ -407,6 +422,13 @@ func (c *Config) ClaudeChatPermissionMode() string {
 
 func (c *Config) CodexChatPermissionMode() string {
 	if mode := strings.TrimSpace(c.Providers.Codex.Chat.PermissionMode); mode != "" {
+		return NormalizeCodexPermissionMode(mode)
+	}
+	return NormalizeCodexPermissionMode(c.RC.PermissionMode)
+}
+
+func (c *Config) GeminiChatPermissionMode() string {
+	if mode := strings.TrimSpace(c.Providers.Gemini.Chat.PermissionMode); mode != "" {
 		return NormalizeCodexPermissionMode(mode)
 	}
 	return NormalizeCodexPermissionMode(c.RC.PermissionMode)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -241,6 +241,9 @@ func TestValidateCodexPermissionMode(t *testing.T) {
 		PermissionModeReadOnly,
 		PermissionModeWorkspace,
 		PermissionModeDangerFull,
+		PermissionModeGeminiAutoEdit,
+		PermissionModeGeminiPlan,
+		PermissionModeGeminiYolo,
 	}
 
 	for _, mode := range validModes {
@@ -252,7 +255,7 @@ func TestValidateCodexPermissionMode(t *testing.T) {
 	}
 
 	t.Run("invalid mode", func(t *testing.T) {
-		err := ValidateCodexPermissionMode("plan")
+		err := ValidateCodexPermissionMode("invalid-mode")
 		if err == nil {
 			t.Fatal("expected invalid mode error")
 		}
@@ -276,7 +279,7 @@ func TestConfigValidatePermissionMode(t *testing.T) {
 		},
 		RC: RCConfig{
 			BaseFolder:          tmpDir,
-			PermissionMode:      "plan",
+			PermissionMode:      "unsupported-mode",
 			AutoRestart:         true,
 			MaxRestarts:         3,
 			RestartDelaySeconds: 5,
@@ -367,7 +370,7 @@ func TestConfigValidateProviderSpecificSettings(t *testing.T) {
 		Providers: ProvidersConfig{
 			Claude: ClaudeProviderConfig{
 				Chat: ProviderChatConfig{
-					PermissionMode: "plan",
+					PermissionMode: "invalid-provider-mode",
 				},
 			},
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -235,32 +235,40 @@ func TestRedactToken(t *testing.T) {
 }
 
 func TestValidateCodexPermissionMode(t *testing.T) {
-	validModes := []string{
+	validCodexModes := []string{
 		"",
 		PermissionModeBypass,
 		PermissionModeReadOnly,
 		PermissionModeWorkspace,
 		PermissionModeDangerFull,
-		PermissionModeGeminiAutoEdit,
-		PermissionModeGeminiPlan,
-		PermissionModeGeminiYolo,
 	}
 
-	for _, mode := range validModes {
-		t.Run("valid "+NormalizeCodexPermissionMode(mode), func(t *testing.T) {
+	for _, mode := range validCodexModes {
+		t.Run("valid codex "+NormalizeCodexPermissionMode(mode), func(t *testing.T) {
 			if err := ValidateCodexPermissionMode(mode); err != nil {
 				t.Fatalf("expected mode %q to be valid, got %v", mode, err)
 			}
 		})
 	}
 
-	t.Run("invalid mode", func(t *testing.T) {
-		err := ValidateCodexPermissionMode("invalid-mode")
+	validGeminiModes := []string{
+		PermissionModeGeminiAutoEdit,
+		PermissionModeGeminiPlan,
+		PermissionModeGeminiYolo,
+	}
+
+	for _, mode := range validGeminiModes {
+		t.Run("valid gemini "+mode, func(t *testing.T) {
+			if err := ValidateGeminiPermissionMode(mode); err != nil {
+				t.Fatalf("expected mode %q to be valid for Gemini, got %v", mode, err)
+			}
+		})
+	}
+
+	t.Run("invalid codex mode", func(t *testing.T) {
+		err := ValidateCodexPermissionMode("plan")
 		if err == nil {
-			t.Fatal("expected invalid mode error")
-		}
-		if !strings.Contains(err.Error(), PermissionModeWorkspace) {
-			t.Fatalf("expected allowed values in error, got %v", err)
+			t.Fatal("expected invalid mode error for Codex")
 		}
 	})
 }

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -1,0 +1,517 @@
+package gemini
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/zevro-ai/remote-control-on-demand/internal/bashcmd"
+	"github.com/zevro-ai/remote-control-on-demand/internal/chat"
+	"github.com/zevro-ai/remote-control-on-demand/internal/config"
+	"github.com/zevro-ai/remote-control-on-demand/internal/provider"
+)
+
+const (
+	defaultPermissionMode = "auto_edit"
+	defaultSystemPATH     = "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin"
+)
+
+var runGeminiFn = runGemini
+
+type Manager struct {
+	core           *chat.Core
+	mu             sync.Mutex
+	model          string
+	permissionMode string
+}
+
+func NewManager(baseFolder, statePath string) *Manager {
+	return &Manager{
+		core:           chat.NewCore(baseFolder, statePath, chat.DefaultMaxMessages),
+		permissionMode: defaultPermissionMode,
+	}
+}
+
+func (m *Manager) Restore() error {
+	return m.core.Restore()
+}
+
+func (m *Manager) SetModel(model string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.model = strings.TrimSpace(model)
+}
+
+func (m *Manager) ConfigurePermissionMode(mode string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.permissionMode = normalizePermissionMode(mode)
+}
+
+func normalizePermissionMode(mode string) string {
+	switch config.NormalizeCodexPermissionMode(mode) {
+	case config.PermissionModeBypass, config.PermissionModeDangerFull:
+		return "yolo"
+	case config.PermissionModeReadOnly:
+		return "plan"
+	default:
+		return defaultPermissionMode
+	}
+}
+
+func (m *Manager) Subscribe(fn func(chat.Event)) func() {
+	return m.core.Subscribe(fn)
+}
+
+func (m *Manager) emit(e chat.Event) {
+	m.core.Emit(e)
+}
+
+func (m *Manager) Shutdown() {
+	m.core.Shutdown()
+}
+
+func (m *Manager) BaseFolder() string {
+	return m.core.BaseFolder()
+}
+
+func (m *Manager) Active() (*chat.Session, bool) {
+	return m.core.Active()
+}
+
+func (m *Manager) SetActive(id string) (*chat.Session, error) {
+	return m.core.SetActive(id)
+}
+
+func (m *Manager) ResolveActive() (*chat.Session, error) {
+	return m.core.ResolveActive("no Gemini session yet; use /new or /folders first", "no active session selected; use /use or /sessions")
+}
+
+func (m *Manager) Metadata() provider.Metadata {
+	return provider.Metadata{
+		ID:          "gemini",
+		DisplayName: "Gemini",
+		Chat: &provider.ChatCapabilities{
+			StreamingDeltas:  true,
+			ShellCommandExec: true,
+			ThreadResume:     true,
+			ImageAttachments: false, // gemini-cli supports images but RCOD doesn't yet handle it for Gemini
+		},
+	}
+}
+
+func (m *Manager) ID() string {
+	return m.Metadata().ID
+}
+
+func (m *Manager) CreateSession(folder string) (*chat.Session, error) {
+	return m.core.CreateSession(folder)
+}
+
+func (m *Manager) ListSessions() []*chat.Session {
+	return m.core.ListSessions()
+}
+
+func (m *Manager) GetSession(id string) (*chat.Session, bool) {
+	return m.core.GetSession(id)
+}
+
+func (m *Manager) DeleteSession(id string) error {
+	return m.core.DeleteSession(id)
+}
+
+func (m *Manager) SendMessage(ctx context.Context, id, prompt string, attachments []chat.Attachment) error {
+	_, _, err := m.Send(ctx, id, prompt, attachments)
+	return err
+}
+
+func (m *Manager) RunCommand(ctx context.Context, id, command string) error {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return fmt.Errorf("command cannot be empty")
+	}
+
+	userMessage := chat.Message{
+		Role:      "user",
+		Kind:      "bash",
+		Content:   command,
+		Timestamp: time.Now(),
+		Command:   &chat.CommandMeta{Command: command},
+	}
+	request, snapshot, err := m.core.BeginRequest(id, userMessage)
+	if err != nil {
+		return err
+	}
+
+	result, err := bashcmd.Run(ctx, snapshot.Folder, command)
+
+	_, saveErr := request.Complete(func(current *chat.Session) *chat.Message {
+		if err != nil {
+			return nil
+		}
+		reply := &chat.Message{
+			Role:      "assistant",
+			Kind:      "bash_result",
+			Content:   result.Output,
+			Timestamp: time.Now(),
+			Command: &chat.CommandMeta{
+				Command:    result.Command,
+				ExitCode:   result.ExitCode,
+				DurationMs: result.DurationMs,
+				TimedOut:   result.TimedOut,
+				Truncated:  result.Truncated,
+			},
+		}
+		current.Messages = chat.AppendMessageWithLimit(current.Messages, *reply, m.core.MaxMessages())
+		return reply
+	})
+
+	if err != nil {
+		if saveErr != nil {
+			return fmt.Errorf("%w (state save failed: %v)", err, saveErr)
+		}
+		return err
+	}
+	return saveErr
+}
+
+func (m *Manager) Send(ctx context.Context, id, prompt string, attachments []chat.Attachment) (*chat.Session, string, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" && len(attachments) == 0 {
+		return nil, "", fmt.Errorf("message cannot be empty")
+	}
+
+	userMessage := chat.Message{
+		Role:        "user",
+		Kind:        "text",
+		Content:     prompt,
+		Timestamp:   time.Now(),
+		Attachments: chat.CloneAttachments(attachments),
+	}
+
+	m.mu.Lock()
+	model := m.model
+	permissionMode := m.permissionMode
+	m.mu.Unlock()
+
+	request, snapshot, err := m.core.BeginRequest(id, userMessage)
+	if err != nil {
+		return nil, "", err
+	}
+
+	threadID, reply, err := runGeminiFn(ctx, snapshot, prompt, permissionMode, model, StreamCallback{
+		OnTextDelta: func(delta string) {
+			m.emit(chat.Event{Type: chat.EventMessageDelta, SessionID: id, Delta: delta})
+		},
+		OnToolStart: func(index int, toolID, name string, parameters json.RawMessage) {
+			m.emit(chat.Event{Type: chat.EventToolUseStart, SessionID: id, ToolCall: &chat.ToolCallEvent{Index: index, ID: toolID, Name: name}})
+			if len(parameters) > 0 {
+				m.emit(chat.Event{Type: chat.EventToolUseDelta, SessionID: id, ToolCall: &chat.ToolCallEvent{Index: index, PartialJSON: string(parameters)}})
+			}
+		},
+		OnToolFinish: func(index int) {
+			m.emit(chat.Event{Type: chat.EventToolUseFinish, SessionID: id, ToolCall: &chat.ToolCallEvent{Index: index}})
+		},
+	})
+
+	clone, saveErr := request.Complete(func(current *chat.Session) *chat.Message {
+		if threadID != "" {
+			current.ThreadID = threadID
+			current.ThreadReady = true
+		}
+		if err != nil || reply == "" {
+			return nil
+		}
+		assistantMessage := &chat.Message{Role: "assistant", Kind: "text", Content: reply, Timestamp: time.Now()}
+		current.Messages = chat.AppendMessageWithLimit(current.Messages, *assistantMessage, m.core.MaxMessages())
+		return assistantMessage
+	})
+
+	if err != nil {
+		if saveErr != nil {
+			return nil, "", fmt.Errorf("%w (state save failed: %v)", err, saveErr)
+		}
+		return nil, "", err
+	}
+	if saveErr != nil {
+		return nil, "", saveErr
+	}
+
+	return clone, reply, nil
+}
+
+func runGemini(ctx context.Context, sess *chat.Session, prompt, permissionMode, model string, cb StreamCallback) (string, string, error) {
+	geminiBin, cmdEnv, err := resolveGeminiCommandEnv()
+	if err != nil {
+		return "", "", fmt.Errorf("starting gemini: %w", err)
+	}
+
+	args := buildGeminiArgs(sess, prompt, permissionMode, model)
+	cmd := exec.CommandContext(ctx, geminiBin, args...)
+	cmd.Dir = sess.Folder
+	cmd.Env = cmdEnv
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", "", fmt.Errorf("creating stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return "", "", fmt.Errorf("creating stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return "", "", fmt.Errorf("starting gemini: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	var result execResult
+	var stdoutBuf strings.Builder
+	var stderrBuf strings.Builder
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		parseExecOutput(stdout, &result, &stdoutBuf, cb)
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&stderrBuf, stderr)
+	}()
+
+	waitErr := cmd.Wait()
+	wg.Wait()
+
+	if waitErr != nil {
+		detail := strings.TrimSpace(stderrBuf.String())
+		if detail == "" {
+			detail = strings.TrimSpace(stdoutBuf.String())
+		}
+		if detail == "" {
+			detail = waitErr.Error()
+		}
+		return result.SessionID, strings.TrimSpace(result.Response), fmt.Errorf("gemini command failed: %s", detail)
+	}
+
+	reply := strings.TrimSpace(result.Response)
+	if reply == "" {
+		reply = strings.TrimSpace(stdoutBuf.String())
+	}
+	if reply == "" {
+		return result.SessionID, "", fmt.Errorf("gemini returned an empty response")
+	}
+
+	return result.SessionID, reply, nil
+}
+
+func buildGeminiArgs(sess *chat.Session, prompt, permissionMode, model string) []string {
+	args := []string{
+		"--output-format", "stream-json",
+		"--approval-mode", permissionMode,
+	}
+
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+
+	if sess.ThreadID != "" && sess.ThreadReady {
+		args = append(args, "--resume", sess.ThreadID)
+	}
+
+	args = append(args, "-p", prompt)
+	return args
+}
+
+type execResult struct {
+	SessionID string
+	Response  string
+}
+
+type streamEnvelope struct {
+	Type       string          `json:"type"`
+	SessionID  string          `json:"session_id,omitempty"`
+	Role       string          `json:"role,omitempty"`
+	Content    string          `json:"content,omitempty"`
+	Delta      bool            `json:"delta,omitempty"`
+	ToolName   string          `json:"tool_name,omitempty"`
+	ToolID     string          `json:"tool_id,omitempty"`
+	Parameters json.RawMessage `json:"parameters,omitempty"`
+}
+
+type StreamCallback struct {
+	OnTextDelta  func(delta string)
+	OnToolStart  func(index int, toolID, name string, parameters json.RawMessage)
+	OnToolFinish func(index int)
+}
+
+func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb StreamCallback) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	var partial strings.Builder
+	var nextToolIndex int
+	toolMap := make(map[string]int)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		raw.WriteString(line)
+		raw.WriteByte('\n')
+
+		var event streamEnvelope
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			continue
+		}
+
+		switch event.Type {
+		case "init":
+			if event.SessionID != "" {
+				result.SessionID = event.SessionID
+			}
+		case "message":
+			if event.Role == "assistant" && event.Content != "" {
+				if event.Delta {
+					partial.WriteString(event.Content)
+					if cb.OnTextDelta != nil {
+						cb.OnTextDelta(event.Content)
+					}
+				} else {
+					// Full message at once? (Should not happen with stream-json but handle just in case)
+					if partial.Len() == 0 {
+						partial.WriteString(event.Content)
+						if cb.OnTextDelta != nil {
+							cb.OnTextDelta(event.Content)
+						}
+					}
+				}
+			}
+		case "tool_use":
+			idx := nextToolIndex
+			nextToolIndex++
+			if event.ToolID != "" {
+				toolMap[event.ToolID] = idx
+			}
+			if cb.OnToolStart != nil {
+				cb.OnToolStart(idx, event.ToolID, event.ToolName, event.Parameters)
+			}
+		case "tool_result":
+			if idx, ok := toolMap[event.ToolID]; ok {
+				if cb.OnToolFinish != nil {
+					cb.OnToolFinish(idx)
+				}
+				delete(toolMap, event.ToolID)
+			}
+		}
+	}
+
+	result.Response = partial.String()
+}
+
+func resolveGeminiCommandEnv() (string, []string, error) {
+	geminiBin, err := resolveGeminiBinary()
+	if err != nil {
+		return "", nil, err
+	}
+
+	env := withPATH(os.Environ(), filepath.Dir(geminiBin))
+	env = ensureHome(env)
+	return geminiBin, env, nil
+}
+
+func resolveGeminiBinary() (string, error) {
+	if configured := strings.TrimSpace(os.Getenv("GEMINI_BIN")); configured != "" {
+		path, err := validateExecutable(configured)
+		if err != nil {
+			return "", fmt.Errorf("GEMINI_BIN=%q is invalid: %w", configured, err)
+		}
+		return path, nil
+	}
+
+	if path, err := exec.LookPath("gemini"); err == nil {
+		return path, nil
+	}
+
+	// Add common locations if needed, similar to Claude
+	return "", fmt.Errorf("could not find gemini in PATH")
+}
+
+func validateExecutable(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("path is a directory")
+	}
+	if info.Mode()&0111 == 0 {
+		return "", fmt.Errorf("path is not executable")
+	}
+	return path, nil
+}
+
+func withPATH(env []string, preferredDir string) []string {
+	pathEntries := []string{preferredDir}
+	pathEntries = append(pathEntries, filepath.SplitList(envValue(env, "PATH"))...)
+	pathEntries = append(pathEntries, filepath.SplitList(defaultSystemPATH)...)
+	return setEnv(env, "PATH", joinUniquePath(pathEntries))
+}
+
+func ensureHome(env []string) []string {
+	if strings.TrimSpace(envValue(env, "HOME")) != "" {
+		return env
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return setEnv(env, "HOME", home)
+	}
+	return env
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
+}
+
+func setEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env)+1)
+	replaced := false
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			if !replaced {
+				out = append(out, prefix+value)
+				replaced = true
+			}
+			continue
+		}
+		out = append(out, entry)
+	}
+	if !replaced {
+		out = append(out, prefix+value)
+	}
+	return out
+}
+
+func joinUniquePath(entries []string) string {
+	seen := make(map[string]bool)
+	unique := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if strings.TrimSpace(entry) == "" || seen[entry] {
+			continue
+		}
+		seen[entry] = true
+		unique = append(unique, entry)
+	}
+	return strings.Join(unique, string(os.PathListSeparator))
+}

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -450,8 +451,51 @@ func resolveGeminiBinary() (string, error) {
 		return path, nil
 	}
 
-	// Add common locations if needed, similar to Claude
-	return "", fmt.Errorf("could not find gemini in PATH")
+	for _, candidate := range geminiCandidatePaths() {
+		if path, err := validateExecutable(candidate); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find gemini in PATH or common install locations")
+}
+
+func geminiCandidatePaths() []string {
+	var candidates []string
+	seen := make(map[string]bool)
+
+	addCandidate := func(path string) {
+		path = strings.TrimSpace(path)
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		candidates = append(candidates, path)
+	}
+
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		addCandidate(filepath.Join(dir, "gemini"))
+	}
+
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		for _, pattern := range []string{
+			filepath.Join(home, ".nvm", "versions", "node", "*", "bin", "gemini"),
+			filepath.Join(home, ".volta", "bin", "gemini"),
+			filepath.Join(home, ".local", "bin", "gemini"),
+		} {
+			matches, _ := filepath.Glob(pattern)
+			sort.Sort(sort.Reverse(sort.StringSlice(matches)))
+			for _, match := range matches {
+				addCandidate(match)
+			}
+		}
+	}
+
+	for _, dir := range []string{"/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"} {
+		addCandidate(filepath.Join(dir, "gemini"))
+	}
+
+	return candidates
 }
 
 func validateExecutable(path string) (string, error) {

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -261,10 +261,11 @@ func runGemini(ctx context.Context, sess *chat.Session, prompt, permissionMode, 
 		return "", "", fmt.Errorf("starting gemini: %w", err)
 	}
 
-	args := buildGeminiArgs(sess, prompt, permissionMode, model)
+	args := buildGeminiArgs(sess, permissionMode, model)
 	cmd := exec.CommandContext(ctx, geminiBin, args...)
 	cmd.Dir = sess.Folder
 	cmd.Env = cmdEnv
+	cmd.Stdin = strings.NewReader(prompt)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -319,7 +320,7 @@ func runGemini(ctx context.Context, sess *chat.Session, prompt, permissionMode, 
 	return result.SessionID, reply, nil
 }
 
-func buildGeminiArgs(sess *chat.Session, prompt, permissionMode, model string) []string {
+func buildGeminiArgs(sess *chat.Session, permissionMode, model string) []string {
 	args := []string{
 		"--output-format", "stream-json",
 		"--approval-mode", permissionMode,
@@ -333,7 +334,6 @@ func buildGeminiArgs(sess *chat.Session, prompt, permissionMode, model string) [
 		args = append(args, "--resume", sess.ThreadID)
 	}
 
-	args = append(args, "-p", prompt)
 	return args
 }
 
@@ -423,15 +423,26 @@ func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb S
 	result.Response = partial.String()
 }
 
-func resolveGeminiCommandEnv() (string, []string, error) {
-	geminiBin, err := resolveGeminiBinary()
-	if err != nil {
-		return "", nil, err
-	}
+var (
+	geminiBinCache string
+	geminiEnvCache []string
+	geminiErrCache error
+	geminiOnce     sync.Once
+)
 
-	env := withPATH(os.Environ(), filepath.Dir(geminiBin))
-	env = ensureHome(env)
-	return geminiBin, env, nil
+func resolveGeminiCommandEnv() (string, []string, error) {
+	geminiOnce.Do(func() {
+		geminiBinCache, geminiErrCache = resolveGeminiBinary()
+		if geminiErrCache == nil {
+			env := withPATH(os.Environ(), filepath.Dir(geminiBinCache))
+			geminiEnvCache = ensureHome(env)
+		}
+	})
+
+	if geminiErrCache != nil {
+		return "", nil, geminiErrCache
+	}
+	return geminiBinCache, geminiEnvCache, nil
 }
 
 func resolveGeminiBinary() (string, error) {

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -355,61 +355,61 @@ type StreamCallback struct {
 }
 
 func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb StreamCallback) {
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	reader := bufio.NewReader(r)
 
 	var partial strings.Builder
 	var nextToolIndex int
 	toolMap := make(map[string]int)
 
-	for scanner.Scan() {
-		line := scanner.Text()
-		raw.WriteString(line)
-		raw.WriteByte('\n')
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			raw.Write(line)
 
-		var event streamEnvelope
-		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			continue
-		}
-
-		switch event.Type {
-		case "init":
-			if event.SessionID != "" {
-				result.SessionID = event.SessionID
-			}
-		case "message":
-			if event.Role == "assistant" && event.Content != "" {
-				if event.Delta {
-					partial.WriteString(event.Content)
-					if cb.OnTextDelta != nil {
-						cb.OnTextDelta(event.Content)
+			var event streamEnvelope
+			if err := json.Unmarshal(line, &event); err == nil {
+				switch event.Type {
+				case "init":
+					if event.SessionID != "" {
+						result.SessionID = event.SessionID
 					}
-				} else {
-					// Full message at once? (Should not happen with stream-json but handle just in case)
-					if partial.Len() == 0 {
-						partial.WriteString(event.Content)
-						if cb.OnTextDelta != nil {
-							cb.OnTextDelta(event.Content)
+				case "message":
+					if event.Role == "assistant" && event.Content != "" {
+						if event.Delta {
+							partial.WriteString(event.Content)
+							if cb.OnTextDelta != nil {
+								cb.OnTextDelta(event.Content)
+							}
+						} else {
+							if partial.Len() == 0 {
+								partial.WriteString(event.Content)
+								if cb.OnTextDelta != nil {
+									cb.OnTextDelta(event.Content)
+								}
+							}
 						}
 					}
+				case "tool_use":
+					idx := nextToolIndex
+					nextToolIndex++
+					if event.ToolID != "" {
+						toolMap[event.ToolID] = idx
+					}
+					if cb.OnToolStart != nil {
+						cb.OnToolStart(idx, event.ToolID, event.ToolName, event.Parameters)
+					}
+				case "tool_result":
+					if idx, ok := toolMap[event.ToolID]; ok {
+						if cb.OnToolFinish != nil {
+							cb.OnToolFinish(idx)
+						}
+						delete(toolMap, event.ToolID)
+					}
 				}
 			}
-		case "tool_use":
-			idx := nextToolIndex
-			nextToolIndex++
-			if event.ToolID != "" {
-				toolMap[event.ToolID] = idx
-			}
-			if cb.OnToolStart != nil {
-				cb.OnToolStart(idx, event.ToolID, event.ToolName, event.Parameters)
-			}
-		case "tool_result":
-			if idx, ok := toolMap[event.ToolID]; ok {
-				if cb.OnToolFinish != nil {
-					cb.OnToolFinish(idx)
-				}
-				delete(toolMap, event.ToolID)
-			}
+		}
+		if err != nil {
+			break
 		}
 	}
 

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -186,8 +186,12 @@ func (m *Manager) RunCommand(ctx context.Context, id, command string) error {
 }
 
 func (m *Manager) Send(ctx context.Context, id, prompt string, attachments []chat.Attachment) (*chat.Session, string, error) {
+	if len(attachments) > 0 {
+		return nil, "", fmt.Errorf("Gemini chat provider does not support attachments")
+	}
+
 	prompt = strings.TrimSpace(prompt)
-	if prompt == "" && len(attachments) == 0 {
+	if prompt == "" {
 		return nil, "", fmt.Errorf("message cannot be empty")
 	}
 

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -434,7 +434,13 @@ func resolveGeminiCommandEnv() (string, []string, error) {
 	geminiOnce.Do(func() {
 		geminiBinCache, geminiErrCache = resolveGeminiBinary()
 		if geminiErrCache == nil {
-			env := withPATH(os.Environ(), filepath.Dir(geminiBinCache))
+			var cleanEnv []string
+			for _, key := range []string{"GEMINI_API_KEY", "USER", "LOGNAME", "HOME", "PATH"} {
+				if val := os.Getenv(key); val != "" {
+					cleanEnv = append(cleanEnv, key+"="+val)
+				}
+			}
+			env := withPATH(cleanEnv, filepath.Dir(geminiBinCache))
 			geminiEnvCache = ensureHome(env)
 		}
 	})

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -435,7 +435,13 @@ func resolveGeminiCommandEnv() (string, []string, error) {
 		geminiBinCache, geminiErrCache = resolveGeminiBinary()
 		if geminiErrCache == nil {
 			var cleanEnv []string
-			for _, key := range []string{"GEMINI_API_KEY", "USER", "LOGNAME", "HOME", "PATH"} {
+			allowedVars := []string{
+				"GEMINI_API_KEY", "USER", "LOGNAME", "HOME", "PATH",
+				"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+				"http_proxy", "https_proxy", "no_proxy",
+				"REQUESTS_CA_BUNDLE", "SSL_CERT_FILE",
+			}
+			for _, key := range allowedVars {
 				if val := os.Getenv(key); val != "" {
 					cleanEnv = append(cleanEnv, key+"="+val)
 				}

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -58,10 +58,12 @@ func (m *Manager) ConfigurePermissionMode(mode string) {
 
 func normalizePermissionMode(mode string) string {
 	switch config.NormalizeCodexPermissionMode(mode) {
-	case config.PermissionModeBypass, config.PermissionModeDangerFull:
+	case config.PermissionModeBypass, config.PermissionModeDangerFull, config.PermissionModeGeminiYolo:
 		return "yolo"
-	case config.PermissionModeReadOnly:
+	case config.PermissionModeReadOnly, config.PermissionModeGeminiPlan:
 		return "plan"
+	case config.PermissionModeGeminiAutoEdit:
+		return "auto_edit"
 	default:
 		return defaultPermissionMode
 	}

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -62,7 +62,7 @@ func normalizePermissionMode(mode string) string {
 		return "yolo"
 	case config.PermissionModeReadOnly, config.PermissionModeGeminiPlan:
 		return "plan"
-	case config.PermissionModeGeminiAutoEdit:
+	case config.PermissionModeGeminiAutoEdit, config.PermissionModeWorkspace:
 		return "auto_edit"
 	default:
 		return defaultPermissionMode

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -427,7 +427,11 @@ func resolveGeminiCommandEnv() (string, []string, error) {
 
 func resolveGeminiBinary() (string, error) {
 	if configured := strings.TrimSpace(os.Getenv("GEMINI_BIN")); configured != "" {
-		path, err := validateExecutable(configured)
+		absPath, err := filepath.Abs(configured)
+		if err != nil {
+			return "", fmt.Errorf("resolving absolute path for GEMINI_BIN=%q: %w", configured, err)
+		}
+		path, err := validateExecutable(absPath)
 		if err != nil {
 			return "", fmt.Errorf("GEMINI_BIN=%q is invalid: %w", configured, err)
 		}

--- a/internal/gemini/manager.go
+++ b/internal/gemini/manager.go
@@ -355,62 +355,64 @@ type StreamCallback struct {
 }
 
 func parseExecOutput(r io.Reader, result *execResult, raw *strings.Builder, cb StreamCallback) {
-	reader := bufio.NewReader(r)
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 
 	var partial strings.Builder
 	var nextToolIndex int
 	toolMap := make(map[string]int)
 
-	for {
-		line, err := reader.ReadBytes('\n')
-		if len(line) > 0 {
-			raw.Write(line)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		raw.Write(line)
+		raw.WriteByte('\n')
 
-			var event streamEnvelope
-			if err := json.Unmarshal(line, &event); err == nil {
-				switch event.Type {
-				case "init":
-					if event.SessionID != "" {
-						result.SessionID = event.SessionID
-					}
-				case "message":
-					if event.Role == "assistant" && event.Content != "" {
-						if event.Delta {
+		var event streamEnvelope
+		if err := json.Unmarshal(line, &event); err == nil {
+			switch event.Type {
+			case "init":
+				if event.SessionID != "" {
+					result.SessionID = event.SessionID
+				}
+			case "message":
+				if event.Role == "assistant" && event.Content != "" {
+					if event.Delta {
+						partial.WriteString(event.Content)
+						if cb.OnTextDelta != nil {
+							cb.OnTextDelta(event.Content)
+						}
+					} else {
+						if partial.Len() == 0 {
 							partial.WriteString(event.Content)
 							if cb.OnTextDelta != nil {
 								cb.OnTextDelta(event.Content)
 							}
-						} else {
-							if partial.Len() == 0 {
-								partial.WriteString(event.Content)
-								if cb.OnTextDelta != nil {
-									cb.OnTextDelta(event.Content)
-								}
-							}
 						}
 					}
-				case "tool_use":
-					idx := nextToolIndex
-					nextToolIndex++
-					if event.ToolID != "" {
-						toolMap[event.ToolID] = idx
+				}
+			case "tool_use":
+				idx := nextToolIndex
+				nextToolIndex++
+				if event.ToolID != "" {
+					toolMap[event.ToolID] = idx
+				}
+				if cb.OnToolStart != nil {
+					cb.OnToolStart(idx, event.ToolID, event.ToolName, event.Parameters)
+				}
+			case "tool_result":
+				if idx, ok := toolMap[event.ToolID]; ok {
+					if cb.OnToolFinish != nil {
+						cb.OnToolFinish(idx)
 					}
-					if cb.OnToolStart != nil {
-						cb.OnToolStart(idx, event.ToolID, event.ToolName, event.Parameters)
-					}
-				case "tool_result":
-					if idx, ok := toolMap[event.ToolID]; ok {
-						if cb.OnToolFinish != nil {
-							cb.OnToolFinish(idx)
-						}
-						delete(toolMap, event.ToolID)
-					}
+					delete(toolMap, event.ToolID)
 				}
 			}
 		}
-		if err != nil {
-			break
-		}
+	}
+
+	// Drain remaining output if scanner failed (e.g. line too long)
+	if err := scanner.Err(); err != nil {
+		_, _ = io.Copy(io.Discard, r)
 	}
 
 	result.Response = partial.String()

--- a/internal/gemini/manager_test.go
+++ b/internal/gemini/manager_test.go
@@ -1,0 +1,174 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zevro-ai/remote-control-on-demand/internal/chat"
+	"github.com/zevro-ai/remote-control-on-demand/internal/provider"
+)
+
+func TestManagerMetadata(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(t.TempDir(), "")
+	metadata := mgr.Metadata()
+
+	if metadata.ID != "gemini" {
+		t.Fatalf("metadata.ID = %q, want %q", metadata.ID, "gemini")
+	}
+	if metadata.DisplayName != "Gemini" {
+		t.Fatalf("metadata.DisplayName = %q, want %q", metadata.DisplayName, "Gemini")
+	}
+	if metadata.Chat == nil {
+		t.Fatal("metadata.Chat = nil, want chat capabilities")
+	}
+	want := provider.ChatCapabilities{
+		StreamingDeltas:  true,
+		ShellCommandExec: true,
+		ThreadResume:     true,
+		ImageAttachments: false,
+	}
+	if *metadata.Chat != want {
+		t.Fatalf("metadata.Chat = %#v, want %#v", *metadata.Chat, want)
+	}
+}
+
+func TestParseExecOutputStreamsAndFinalizesMessage(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		`{"type":"init","session_id":"sess-123"}`,
+		`{"type":"message","role":"user","content":"hi"}`,
+		`{"type":"message","role":"assistant","content":"hel","delta":true}`,
+		`{"type":"message","role":"assistant","content":"lo","delta":true}`,
+		`{"type":"result","status":"success"}`,
+		"",
+	}, "\n")
+
+	var result execResult
+	var raw strings.Builder
+	var deltas strings.Builder
+
+	parseExecOutput(strings.NewReader(input), &result, &raw, StreamCallback{
+		OnTextDelta: func(delta string) {
+			deltas.WriteString(delta)
+		},
+	})
+
+	if got := deltas.String(); got != "hello" {
+		t.Fatalf("delta stream = %q, want %q", got, "hello")
+	}
+	if got := result.Response; got != "hello" {
+		t.Fatalf("response = %q, want %q", got, "hello")
+	}
+	if result.SessionID != "sess-123" {
+		t.Fatalf("session_id = %q, want %q", result.SessionID, "sess-123")
+	}
+}
+
+func TestParseExecOutputHandlesToolUse(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		`{"type":"message","role":"assistant","content":"Let me check.","delta":true}`,
+		`{"type":"tool_use","tool_name":"ls","tool_id":"call-1","parameters":{"path":"."}}`,
+		`{"type":"tool_result","tool_id":"call-1","status":"success","output":"file.txt"}`,
+		`{"type":"message","role":"assistant","content":" Done.","delta":true}`,
+		"",
+	}, "\n")
+
+	var result execResult
+	var raw strings.Builder
+	var deltas strings.Builder
+
+	var toolStarts []struct {
+		index    int
+		id, name string
+	}
+	var toolFinishes []int
+
+	parseExecOutput(strings.NewReader(input), &result, &raw, StreamCallback{
+		OnTextDelta: func(delta string) {
+			deltas.WriteString(delta)
+		},
+		OnToolStart: func(index int, id, name string, params json.RawMessage) {
+			toolStarts = append(toolStarts, struct {
+				index    int
+				id, name string
+			}{index, id, name})
+		},
+		OnToolFinish: func(index int) {
+			toolFinishes = append(toolFinishes, index)
+		},
+	})
+
+	if got := deltas.String(); got != "Let me check. Done." {
+		t.Fatalf("text deltas = %q", got)
+	}
+
+	if len(toolStarts) != 1 {
+		t.Fatalf("expected 1 tool start, got %d", len(toolStarts))
+	}
+	if toolStarts[0].name != "ls" || toolStarts[0].id != "call-1" {
+		t.Fatalf("tool start = %#v", toolStarts[0])
+	}
+
+	if len(toolFinishes) != 1 || toolFinishes[0] != 0 {
+		t.Fatalf("expected tool finish at index 0, got %v", toolFinishes)
+	}
+}
+
+func TestSendEmitsUserAndAssistantEvents(t *testing.T) {
+	baseDir := t.TempDir()
+	repoDir := filepath.Join(baseDir, "demo")
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0755); err != nil {
+		t.Fatalf("MkdirAll(.git): %v", err)
+	}
+
+	mgr := NewManager(baseDir, "")
+	sess, err := mgr.CreateSession("demo")
+	if err != nil {
+		t.Fatalf("CreateSession(): %v", err)
+	}
+
+	previousRunGeminiFn := runGeminiFn
+	runGeminiFn = func(
+		ctx context.Context,
+		sess *chat.Session,
+		prompt,
+		permissionMode,
+		model string,
+		cb StreamCallback,
+	) (string, string, error) {
+		return "sess-abc", "assistant reply", nil
+	}
+	t.Cleanup(func() {
+		runGeminiFn = previousRunGeminiFn
+	})
+
+	var events []chat.Message
+	mgr.Subscribe(func(event chat.Event) {
+		if event.Type == chat.EventMessageReceived && event.Message != nil {
+			events = append(events, *event.Message)
+		}
+	})
+
+	_, _, err = mgr.Send(context.Background(), sess.ID, "ping", nil)
+	if err != nil {
+		t.Fatalf("Send(): %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2", len(events))
+	}
+	if events[0].Role != "user" || events[0].Content != "ping" {
+		t.Fatalf("user event = %#v", events[0])
+	}
+	if events[1].Role != "assistant" || events[1].Content != "assistant reply" {
+		t.Fatalf("assistant event = %#v", events[1])
+	}
+}

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"encoding/json"
 	"github.com/zevro-ai/remote-control-on-demand/internal/botutil"
 	"github.com/zevro-ai/remote-control-on-demand/internal/chat"
 	"github.com/zevro-ai/remote-control-on-demand/internal/codex"
@@ -15,6 +16,7 @@ import (
 	"github.com/zevro-ai/remote-control-on-demand/internal/provider"
 	"github.com/zevro-ai/remote-control-on-demand/internal/session"
 	tele "gopkg.in/telebot.v4"
+	"os"
 )
 
 // Notifier abstracts the Telegram bot for HTTP-only mode.
@@ -32,6 +34,7 @@ type Bot struct {
 	allowedUserID     int64
 	unsubSession      func()
 	currentProviderID string
+	statePath         string
 }
 
 // NopBot returns a no-op Notifier for HTTP-only mode.
@@ -45,7 +48,7 @@ func (n *nopBot) Start()               {}
 func (n *nopBot) Stop()                {}
 func (n *nopBot) SendMessage(_ string) {}
 
-func New(token string, allowedUserID int64, sessionMgr *session.Manager, codexMgr *codex.Manager, geminiMgr *gemini.Manager) (*Bot, error) {
+func New(token string, allowedUserID int64, sessionMgr *session.Manager, codexMgr *codex.Manager, geminiMgr *gemini.Manager, statePath string) (*Bot, error) {
 	tb, err := tele.NewBot(tele.Settings{
 		Token:  token,
 		Poller: &tele.LongPoller{Timeout: 10 * time.Second},
@@ -60,10 +63,42 @@ func New(token string, allowedUserID int64, sessionMgr *session.Manager, codexMg
 		codexMgr:      codexMgr,
 		geminiMgr:     geminiMgr,
 		allowedUserID: allowedUserID,
+		statePath:     statePath,
 	}
+	b.loadState()
 	b.registerHandlers()
 	b.registerCommands()
 	return b, nil
+}
+
+type botState struct {
+	CurrentProviderID string `json:"current_provider_id"`
+}
+
+func (b *Bot) saveState() {
+	if b.statePath == "" {
+		return
+	}
+	state := botState{CurrentProviderID: b.currentProviderID}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(b.statePath, data, 0600)
+}
+
+func (b *Bot) loadState() {
+	if b.statePath == "" {
+		return
+	}
+	data, err := os.ReadFile(b.statePath)
+	if err != nil {
+		return
+	}
+	var state botState
+	if err := json.Unmarshal(data, &state); err == nil {
+		b.currentProviderID = state.CurrentProviderID
+	}
 }
 
 func (b *Bot) Start() {
@@ -287,6 +322,7 @@ func (b *Bot) handleUse(c tele.Context) error {
 	}
 
 	b.currentProviderID = providerID
+	b.saveState()
 
 	return c.Send(
 		fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)),
@@ -446,6 +482,7 @@ func (b *Bot) handleCallback(c tele.Context) error {
 			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 		}
 		b.currentProviderID = providerID
+		b.saveState()
 		return c.Send(fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)), b.sessionActions(sess), tele.ModeHTML)
 	case "close":
 		if len(parts) != 2 {
@@ -505,18 +542,31 @@ func (b *Bot) sendProviderPickerForFolder(c tele.Context, folder string, text st
 	return c.Send(text, markup, tele.ModeHTML)
 }
 
-func (b *Bot) handleProviderPick(c tele.Context, provider, folder string) error {
-	if folder == "browse" {
+func (b *Bot) handleProviderPick(c tele.Context, provider, folderOrIndex string) error {
+	if folderOrIndex == "browse" {
 		return b.sendChatFolderPicker(c, provider, 0, "<b>Select a repository for <code>"+provider+"</code></b>")
 	}
 
 	folders := b.listGitFolders()
-	index := 0
-	fmt.Sscanf(folder, "%d", &index)
-	if index < 0 || index >= len(folders) {
-		return c.Send("That repository is no longer available. Refresh with /new.")
+	var resolvedFolder string
+
+	// Try as index first
+	var index int
+	if _, err := fmt.Sscanf(folderOrIndex, "%d", &index); err == nil && index >= 0 && index < len(folders) {
+		resolvedFolder = folders[index]
+	} else {
+		// Try as literal folder name
+		for _, f := range folders {
+			if f == folderOrIndex {
+				resolvedFolder = f
+				break
+			}
+		}
 	}
-	resolvedFolder := folders[index]
+
+	if resolvedFolder == "" {
+		return c.Send("That repository is no longer available. Refresh with /new.", tele.ModeHTML)
+	}
 
 	var sess *chat.Session
 	var err error
@@ -531,6 +581,7 @@ func (b *Bot) handleProviderPick(c tele.Context, provider, folder string) error 
 	}
 
 	b.currentProviderID = provider
+	b.saveState()
 
 	msg := fmt.Sprintf(
 		"<b>%s session created</b>\nID: <code>%s</code>\nProject: <code>%s</code>\n\nSend text to chat.",

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zevro-ai/remote-control-on-demand/internal/botutil"
 	"github.com/zevro-ai/remote-control-on-demand/internal/chat"
 	"github.com/zevro-ai/remote-control-on-demand/internal/codex"
+	"github.com/zevro-ai/remote-control-on-demand/internal/gemini"
 	"github.com/zevro-ai/remote-control-on-demand/internal/session"
 	tele "gopkg.in/telebot.v4"
 )
@@ -25,6 +26,7 @@ type Bot struct {
 	tb            *tele.Bot
 	sessionMgr    *session.Manager
 	codexMgr      *codex.Manager
+	geminiMgr     *gemini.Manager
 	allowedUserID int64
 	unsubSession  func()
 }
@@ -40,7 +42,7 @@ func (n *nopBot) Start()               {}
 func (n *nopBot) Stop()                {}
 func (n *nopBot) SendMessage(_ string) {}
 
-func New(token string, allowedUserID int64, sessionMgr *session.Manager, codexMgr *codex.Manager) (*Bot, error) {
+func New(token string, allowedUserID int64, sessionMgr *session.Manager, codexMgr *codex.Manager, geminiMgr *gemini.Manager) (*Bot, error) {
 	tb, err := tele.NewBot(tele.Settings{
 		Token:  token,
 		Poller: &tele.LongPoller{Timeout: 10 * time.Second},
@@ -53,6 +55,7 @@ func New(token string, allowedUserID int64, sessionMgr *session.Manager, codexMg
 		tb:            tb,
 		sessionMgr:    sessionMgr,
 		codexMgr:      codexMgr,
+		geminiMgr:     geminiMgr,
 		allowedUserID: allowedUserID,
 	}
 	b.registerHandlers()
@@ -127,9 +130,9 @@ func (b *Bot) sendWelcome() {
 	sb.WriteString("<b>RCOD bot is online</b>\n\n")
 	sb.WriteString("<b>Claude remote control</b>\n")
 	sb.WriteString("Use <code>/start</code>, <code>/list</code>, <code>/status</code>, <code>/logs</code>, <code>/restart</code>, <code>/kill</code>, or <code>/folders</code>.\n\n")
-	sb.WriteString("<b>Codex chat</b>\n")
-	sb.WriteString("Use <code>/new repo</code> to create a Codex session, then send plain text to chat with Codex in that repo.\n")
-	sb.WriteString("Use <code>/sessions</code>, <code>/use</code>, <code>/current</code>, and <code>/close</code> to manage Codex chats.\n")
+	sb.WriteString("<b>Codex & Gemini chat</b>\n")
+	sb.WriteString("Use <code>/new repo</code> to create a session, then send plain text to chat with the agent in that repo.\n")
+	sb.WriteString("Use <code>/sessions</code>, <code>/use</code>, <code>/current</code>, and <code>/close</code> to manage chats.\n")
 
 	folders := b.listGitFolders()
 	if len(folders) > 0 {
@@ -137,6 +140,9 @@ func (b *Bot) sendWelcome() {
 	}
 	if active, ok := b.codexMgr.Active(); ok {
 		sb.WriteString(fmt.Sprintf("\nCurrent Codex session: <code>%s</code> in <code>%s</code>", html.EscapeString(active.ID), html.EscapeString(active.RelName)))
+	}
+	if active, ok := b.geminiMgr.Active(); ok {
+		sb.WriteString(fmt.Sprintf("\nCurrent Gemini session: <code>%s</code> in <code>%s</code>", html.EscapeString(active.ID), html.EscapeString(active.RelName)))
 	}
 	b.SendMessage(sb.String())
 }
@@ -553,6 +559,9 @@ func (b *Bot) listGitFolders() []string {
 func (b *Bot) baseFolder() string {
 	if b.codexMgr != nil {
 		return b.codexMgr.BaseFolder()
+	}
+	if b.geminiMgr != nil {
+		return b.geminiMgr.BaseFolder()
 	}
 	if b.sessionMgr != nil {
 		return b.sessionMgr.BaseFolder()

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -290,11 +290,20 @@ func (b *Bot) handleNew(c tele.Context) error {
 	}
 }
 
+type sessionWithProvider struct {
+	sess       *chat.Session
+	providerID string
+}
+
 func (b *Bot) handleSessions(c tele.Context) error {
-	var sessions []*chat.Session
-	sessions = append(sessions, b.codexMgr.ListSessions()...)
+	var sessions []sessionWithProvider
+	for _, s := range b.codexMgr.ListSessions() {
+		sessions = append(sessions, sessionWithProvider{s, "codex"})
+	}
 	if b.geminiMgr != nil {
-		sessions = append(sessions, b.geminiMgr.ListSessions()...)
+		for _, s := range b.geminiMgr.ListSessions() {
+			sessions = append(sessions, sessionWithProvider{s, "gemini"})
+		}
 	}
 
 	if len(sessions) == 0 {
@@ -309,14 +318,12 @@ func (b *Bot) handleSessions(c tele.Context) error {
 
 	var sb strings.Builder
 	sb.WriteString("<b>Chat sessions</b>\n")
-	for _, sess := range sessions {
-		providerID := "codex"
-		isActive := activeCodex != nil && activeCodex.ID == sess.ID
-		if b.geminiMgr != nil {
-			if _, ok := b.geminiMgr.GetSession(sess.ID); ok {
-				providerID = "gemini"
-				isActive = activeGemini != nil && activeGemini.ID == sess.ID
-			}
+	for _, swp := range sessions {
+		isActive := false
+		if swp.providerID == "codex" {
+			isActive = activeCodex != nil && activeCodex.ID == swp.sess.ID
+		} else {
+			isActive = activeGemini != nil && activeGemini.ID == swp.sess.ID
 		}
 
 		marker := " "
@@ -326,9 +333,9 @@ func (b *Bot) handleSessions(c tele.Context) error {
 		sb.WriteString(fmt.Sprintf(
 			"%s <code>%s</code> | <code>%s</code> | %s\n",
 			marker,
-			html.EscapeString(sess.ID),
-			html.EscapeString(sess.RelName),
-			providerID,
+			html.EscapeString(swp.sess.ID),
+			html.EscapeString(swp.sess.RelName),
+			swp.providerID,
 		))
 	}
 
@@ -336,18 +343,30 @@ func (b *Bot) handleSessions(c tele.Context) error {
 }
 
 func (b *Bot) handleUse(c tele.Context) error {
-	id := strings.TrimSpace(c.Message().Payload)
-	if id == "" {
+	payload := strings.TrimSpace(c.Message().Payload)
+	if payload == "" {
 		return b.sendSessionPicker(c, "use", "<b>Select the active session</b>")
+	}
+
+	// For direct commands, we try to guess or require namespacing.
+	// We'll support <provider>:<id> or just <id> (with fallback lookup)
+	parts := strings.Split(payload, ":")
+	var providerID, id string
+	if len(parts) == 2 {
+		providerID, id = parts[0], parts[1]
+	} else {
+		id = payload
 	}
 
 	var sess *chat.Session
 	var err error
-	var providerID string
-	if _, ok := b.codexMgr.GetSession(id); ok {
-		sess, err = b.codexMgr.SetActive(id)
-		providerID = "codex"
-	} else if b.geminiMgr != nil {
+	if providerID == "codex" || providerID == "" {
+		if _, ok := b.codexMgr.GetSession(id); ok {
+			sess, err = b.codexMgr.SetActive(id)
+			providerID = "codex"
+		}
+	}
+	if sess == nil && (providerID == "gemini" || providerID == "") && b.geminiMgr != nil {
 		if _, ok := b.geminiMgr.GetSession(id); ok {
 			sess, err = b.geminiMgr.SetActive(id)
 			providerID = "gemini"
@@ -365,24 +384,35 @@ func (b *Bot) handleUse(c tele.Context) error {
 	b.setCurrentProviderID(providerID)
 
 	return c.Send(
-		fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)),
-		b.sessionActions(sess),
+		fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code> (%s)", html.EscapeString(sess.ID), html.EscapeString(sess.RelName), providerID),
+		b.sessionActions(sess, providerID),
 		tele.ModeHTML,
 	)
 }
 
 func (b *Bot) handleClose(c tele.Context) error {
-	id := strings.TrimSpace(c.Message().Payload)
-	if id == "" {
+	payload := strings.TrimSpace(c.Message().Payload)
+	if payload == "" {
 		return b.sendSessionPicker(c, "close", "<b>Select a session to close</b>")
+	}
+
+	parts := strings.Split(payload, ":")
+	var providerID, id string
+	if len(parts) == 2 {
+		providerID, id = parts[0], parts[1]
+	} else {
+		id = payload
 	}
 
 	var err error
 	var found bool
-	if _, ok := b.codexMgr.GetSession(id); ok {
-		err = b.codexMgr.DeleteSession(id)
-		found = true
-	} else if b.geminiMgr != nil {
+	if providerID == "codex" || providerID == "" {
+		if _, ok := b.codexMgr.GetSession(id); ok {
+			err = b.codexMgr.DeleteSession(id)
+			found = true
+		}
+	}
+	if !found && (providerID == "gemini" || providerID == "") && b.geminiMgr != nil {
 		if _, ok := b.geminiMgr.GetSession(id); ok {
 			err = b.geminiMgr.DeleteSession(id)
 			found = true
@@ -417,6 +447,11 @@ func (b *Bot) handleCurrent(c tele.Context) error {
 	}
 	if hasGemini {
 		sb.WriteString(fmt.Sprintf("<b>Active Gemini</b>: <code>%s</code> in <code>%s</code>\n", html.EscapeString(activeGemini.ID), html.EscapeString(activeGemini.RelName)))
+	}
+
+	currentID := b.getCurrentProviderID()
+	if currentID != "" {
+		sb.WriteString(fmt.Sprintf("\nDefault provider for chat: <b>%s</b>", currentID))
 	}
 
 	return c.Send(sb.String(), tele.ModeHTML)
@@ -458,7 +493,7 @@ func (b *Bot) handleChat(c tele.Context) error {
 			if sess, ok := b.codexMgr.Active(); ok {
 				mgr = b.codexMgr
 				b.setCurrentProviderID("codex")
-				_ = sess // satisfy unused
+				_ = sess
 			}
 		}
 	}
@@ -524,21 +559,16 @@ func (b *Bot) handleCallback(c tele.Context) error {
 		}
 		return b.handleProviderPick(c, parts[1], parts[2])
 	case "use":
-		if len(parts) != 2 {
+		if len(parts) != 3 {
 			return nil
 		}
-		id := parts[1]
+		providerID, id := parts[1], parts[2]
 		var sess *chat.Session
 		var err error
-		var providerID string
-		if _, ok := b.codexMgr.GetSession(id); ok {
+		if providerID == "codex" {
 			sess, err = b.codexMgr.SetActive(id)
-			providerID = "codex"
-		} else if b.geminiMgr != nil {
-			if _, ok := b.geminiMgr.GetSession(id); ok {
-				sess, err = b.geminiMgr.SetActive(id)
-				providerID = "gemini"
-			}
+		} else if providerID == "gemini" && b.geminiMgr != nil {
+			sess, err = b.geminiMgr.SetActive(id)
 		}
 		if sess == nil {
 			return c.Send(fmt.Sprintf("Session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
@@ -547,30 +577,24 @@ func (b *Bot) handleCallback(c tele.Context) error {
 			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 		}
 		b.setCurrentProviderID(providerID)
-		return c.Send(fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)), b.sessionActions(sess), tele.ModeHTML)
+		return c.Send(fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code> (%s)", html.EscapeString(sess.ID), html.EscapeString(sess.RelName), providerID), b.sessionActions(sess, providerID), tele.ModeHTML)
 	case "close":
-		if len(parts) != 2 {
+		if len(parts) != 3 {
 			return nil
 		}
-		id := parts[1]
+		providerID, id := parts[1], parts[2]
 		var err error
-		var found bool
-		if _, ok := b.codexMgr.GetSession(id); ok {
+		if providerID == "codex" {
 			err = b.codexMgr.DeleteSession(id)
-			found = true
-		} else if b.geminiMgr != nil {
-			if _, ok := b.geminiMgr.GetSession(id); ok {
-				err = b.geminiMgr.DeleteSession(id)
-				found = true
-			}
-		}
-		if !found {
+		} else if providerID == "gemini" && b.geminiMgr != nil {
+			err = b.geminiMgr.DeleteSession(id)
+		} else {
 			return c.Send(fmt.Sprintf("Session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
 		}
 		if err != nil {
 			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 		}
-		return c.Send(fmt.Sprintf("Closed session <code>%s</code>.", html.EscapeString(id)), tele.ModeHTML)
+		return c.Send(fmt.Sprintf("Closed session <code>%s</code> (%s).", html.EscapeString(id), providerID), tele.ModeHTML)
 	case "start", "kill", "status", "logs", "restart":
 		if len(parts) != 2 {
 			return nil
@@ -655,7 +679,7 @@ func (b *Bot) handleProviderPick(c tele.Context, provider, indexStr string) erro
 		html.EscapeString(sess.ID),
 		html.EscapeString(sess.RelName),
 	)
-	return c.Send(msg, b.sessionActions(sess), tele.ModeHTML)
+	return c.Send(msg, b.sessionActions(sess, provider), tele.ModeHTML)
 }
 
 func (b *Bot) sendChatFolderPicker(c tele.Context, provider string, page int, text string) error {
@@ -690,10 +714,14 @@ func (b *Bot) handleChatNavigation(c tele.Context, data string) error {
 }
 
 func (b *Bot) sendSessionPicker(c tele.Context, action, text string) error {
-	var sessions []*chat.Session
-	sessions = append(sessions, b.codexMgr.ListSessions()...)
+	var sessions []sessionWithProvider
+	for _, s := range b.codexMgr.ListSessions() {
+		sessions = append(sessions, sessionWithProvider{s, "codex"})
+	}
 	if b.geminiMgr != nil {
-		sessions = append(sessions, b.geminiMgr.ListSessions()...)
+		for _, s := range b.geminiMgr.ListSessions() {
+			sessions = append(sessions, sessionWithProvider{s, "gemini"})
+		}
 	}
 
 	if len(sessions) == 0 {
@@ -701,33 +729,33 @@ func (b *Bot) sendSessionPicker(c tele.Context, action, text string) error {
 	}
 
 	var items []botutil.PickerItem
-	for _, sess := range sessions {
+	for _, swp := range sessions {
 		items = append(items, botutil.PickerItem{
-			Label: fmt.Sprintf("%s - %s", sess.ID, sess.RelName),
-			Data:  action + ":" + sess.ID,
+			Label: fmt.Sprintf("%s - %s (%s)", swp.sess.ID, swp.sess.RelName, swp.providerID),
+			Data:  fmt.Sprintf("%s:%s:%s", action, swp.providerID, swp.sess.ID),
 		})
 	}
 	return c.Send(text, botutil.PickerMarkup(items), tele.ModeHTML)
 }
 
-func (b *Bot) sessionActions(sess *chat.Session) *tele.ReplyMarkup {
+func (b *Bot) sessionActions(sess *chat.Session, providerID string) *tele.ReplyMarkup {
 	markup := &tele.ReplyMarkup{}
 	markup.InlineKeyboard = [][]tele.InlineButton{
 		{
-			{Text: "Use", Data: "use:" + sess.ID},
-			{Text: "Close", Data: "close:" + sess.ID},
+			{Text: "Use", Data: fmt.Sprintf("use:%s:%s", providerID, sess.ID)},
+			{Text: "Close", Data: fmt.Sprintf("close:%s:%s", providerID, sess.ID)},
 		},
 	}
 	return markup
 }
 
-func (b *Bot) sessionPickerMarkup(sessions []*chat.Session) *tele.ReplyMarkup {
+func (b *Bot) sessionPickerMarkup(sessions []sessionWithProvider) *tele.ReplyMarkup {
 	markup := &tele.ReplyMarkup{}
 	var rows [][]tele.InlineButton
-	for _, sess := range sessions {
+	for _, swp := range sessions {
 		rows = append(rows, []tele.InlineButton{
-			{Text: "Use " + sess.ID, Data: "use:" + sess.ID},
-			{Text: "Close", Data: "close:" + sess.ID},
+			{Text: "Use " + swp.sess.ID, Data: fmt.Sprintf("use:%s:%s", swp.providerID, swp.sess.ID)},
+			{Text: "Close", Data: fmt.Sprintf("close:%s:%s", swp.providerID, swp.sess.ID)},
 		})
 	}
 	markup.InlineKeyboard = rows

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -251,10 +251,21 @@ func (b *Bot) handleNew(c tele.Context) error {
 		return b.sendProviderPicker(c, 0, "<b>Select a provider for a new chat session</b>")
 	}
 
-	resolved, matches := botutil.MatchFolderQuery(b.listGitFolders(), folder)
+	folders := b.listGitFolders()
+	resolved, matches := botutil.MatchFolderQuery(folders, folder)
 	switch {
 	case resolved != "":
-		return b.sendProviderPickerForFolder(c, resolved, "<b>Select a provider for <code>"+html.EscapeString(resolved)+"</code></b>")
+		index := -1
+		for i, f := range folders {
+			if f == resolved {
+				index = i
+				break
+			}
+		}
+		if index == -1 {
+			return c.Send("Repository no longer available. Refresh with /new.", tele.ModeHTML)
+		}
+		return b.sendProviderPickerForFolder(c, index, "<b>Select a provider for <code>"+html.EscapeString(resolved)+"</code></b>")
 	case len(matches) == 0:
 		return c.Send(fmt.Sprintf("No project matched <code>%s</code>.", html.EscapeString(folder)), tele.ModeHTML)
 	default:
@@ -539,45 +550,34 @@ func (b *Bot) sendProviderPicker(c tele.Context, page int, text string) error {
 	return c.Send(text, markup, tele.ModeHTML)
 }
 
-func (b *Bot) sendProviderPickerForFolder(c tele.Context, folder string, text string) error {
+func (b *Bot) sendProviderPickerForFolder(c tele.Context, index int, text string) error {
 	markup := &tele.ReplyMarkup{}
 	markup.InlineKeyboard = [][]tele.InlineButton{
 		{
-			{Text: "Codex", Data: "p-pick:codex:" + folder},
-			{Text: "Gemini", Data: "p-pick:gemini:" + folder},
+			{Text: "Codex", Data: fmt.Sprintf("p-pick:codex:%d", index)},
+			{Text: "Gemini", Data: fmt.Sprintf("p-pick:gemini:%d", index)},
 		},
 	}
 	return c.Send(text, markup, tele.ModeHTML)
 }
 
-func (b *Bot) handleProviderPick(c tele.Context, provider, folderOrIndex string) error {
-	if folderOrIndex == "browse" {
+func (b *Bot) handleProviderPick(c tele.Context, provider, indexStr string) error {
+	if indexStr == "browse" {
 		return b.sendChatFolderPicker(c, provider, 0, "<b>Select a repository for <code>"+provider+"</code></b>")
 	}
 
-	folders := b.listGitFolders()
-	var resolvedFolder string
-
-	// Try as index first
-	var index int
-	if _, err := fmt.Sscanf(folderOrIndex, "%d", &index); err == nil && index >= 0 && index < len(folders) {
-		resolvedFolder = folders[index]
-	} else {
-		// Try as literal folder name
-		for _, f := range folders {
-			if f == folderOrIndex {
-				resolvedFolder = f
-				break
-			}
-		}
+	index, err := strconv.Atoi(indexStr)
+	if err != nil {
+		return c.Send("Invalid repository selection.")
 	}
 
-	if resolvedFolder == "" {
+	folders := b.listGitFolders()
+	if index < 0 || index >= len(folders) {
 		return c.Send("That repository is no longer available. Refresh with /new.", tele.ModeHTML)
 	}
+	resolvedFolder := folders[index]
 
 	var sess *chat.Session
-	var err error
 	if provider == "codex" {
 		sess, err = b.codexMgr.CreateSession(resolvedFolder)
 	} else {

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -288,7 +288,6 @@ func (b *Bot) handleUse(c tele.Context) error {
 
 	b.currentProviderID = providerID
 
-
 	return c.Send(
 		fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)),
 		b.sessionActions(sess),

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -176,7 +176,12 @@ func (b *Bot) registerCommands() {
 }
 
 func (b *Bot) sendWelcome() {
-	msg := `<b>RCOD + Codex & Gemini</b>
+	title := "<b>RCOD + Codex</b>"
+	if b.geminiMgr != nil {
+		title = "<b>RCOD + Codex & Gemini</b>"
+	}
+
+	msg := title + `
 
 Remote Control On Demand with AI agents.
 
@@ -185,7 +190,7 @@ Remote Control On Demand with AI agents.
 /list
 /folders
 
-<b>Codex & Gemini chat</b>
+<b>Chat sessions</b>
 /new repo
 /sessions
 /current
@@ -223,7 +228,12 @@ func (b *Bot) handleFolders(c tele.Context) error {
 }
 
 func (b *Bot) handleHelp(c tele.Context) error {
-	msg := `<b>RCOD + Codex & Gemini</b>
+	title := "<b>RCOD + Codex</b>"
+	if b.geminiMgr != nil {
+		title = "<b>RCOD + Codex & Gemini</b>"
+	}
+
+	msg := title + `
 
 <b>Claude remote control</b>
 <code>/start repo</code> start a Claude session
@@ -234,7 +244,7 @@ func (b *Bot) handleHelp(c tele.Context) error {
 <code>/restart id</code> restart a Claude session
 <code>/folders</code> browse repos for Claude
 
-<b>Codex & Gemini chat</b>
+<b>Chat sessions</b>
 <code>/new repo</code> create a chat session
 <code>/sessions</code> list chat sessions
 <code>/use id</code> switch active chat session
@@ -283,23 +293,30 @@ func (b *Bot) handleNew(c tele.Context) error {
 func (b *Bot) handleSessions(c tele.Context) error {
 	var sessions []*chat.Session
 	sessions = append(sessions, b.codexMgr.ListSessions()...)
-	sessions = append(sessions, b.geminiMgr.ListSessions()...)
+	if b.geminiMgr != nil {
+		sessions = append(sessions, b.geminiMgr.ListSessions()...)
+	}
 
 	if len(sessions) == 0 {
 		return c.Send("No chat sessions yet. Use /new.")
 	}
 
 	activeCodex, _ := b.codexMgr.Active()
-	activeGemini, _ := b.geminiMgr.Active()
+	var activeGemini *chat.Session
+	if b.geminiMgr != nil {
+		activeGemini, _ = b.geminiMgr.Active()
+	}
 
 	var sb strings.Builder
 	sb.WriteString("<b>Chat sessions</b>\n")
 	for _, sess := range sessions {
 		providerID := "codex"
 		isActive := activeCodex != nil && activeCodex.ID == sess.ID
-		if _, ok := b.geminiMgr.GetSession(sess.ID); ok {
-			providerID = "gemini"
-			isActive = activeGemini != nil && activeGemini.ID == sess.ID
+		if b.geminiMgr != nil {
+			if _, ok := b.geminiMgr.GetSession(sess.ID); ok {
+				providerID = "gemini"
+				isActive = activeGemini != nil && activeGemini.ID == sess.ID
+			}
 		}
 
 		marker := " "
@@ -330,10 +347,14 @@ func (b *Bot) handleUse(c tele.Context) error {
 	if _, ok := b.codexMgr.GetSession(id); ok {
 		sess, err = b.codexMgr.SetActive(id)
 		providerID = "codex"
-	} else if _, ok = b.geminiMgr.GetSession(id); ok {
-		sess, err = b.geminiMgr.SetActive(id)
-		providerID = "gemini"
-	} else {
+	} else if b.geminiMgr != nil {
+		if _, ok := b.geminiMgr.GetSession(id); ok {
+			sess, err = b.geminiMgr.SetActive(id)
+			providerID = "gemini"
+		}
+	}
+
+	if sess == nil {
 		return c.Send(fmt.Sprintf("Session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
 	}
 
@@ -357,11 +378,18 @@ func (b *Bot) handleClose(c tele.Context) error {
 	}
 
 	var err error
+	var found bool
 	if _, ok := b.codexMgr.GetSession(id); ok {
 		err = b.codexMgr.DeleteSession(id)
-	} else if _, ok = b.geminiMgr.GetSession(id); ok {
-		err = b.geminiMgr.DeleteSession(id)
-	} else {
+		found = true
+	} else if b.geminiMgr != nil {
+		if _, ok := b.geminiMgr.GetSession(id); ok {
+			err = b.geminiMgr.DeleteSession(id)
+			found = true
+		}
+	}
+
+	if !found {
 		return c.Send(fmt.Sprintf("Session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
 	}
 
@@ -373,7 +401,11 @@ func (b *Bot) handleClose(c tele.Context) error {
 
 func (b *Bot) handleCurrent(c tele.Context) error {
 	activeCodex, hasCodex := b.codexMgr.Active()
-	activeGemini, hasGemini := b.geminiMgr.Active()
+	var activeGemini *chat.Session
+	var hasGemini bool
+	if b.geminiMgr != nil {
+		activeGemini, hasGemini = b.geminiMgr.Active()
+	}
 
 	if !hasCodex && !hasGemini {
 		return c.Send("No active session. Use /new or /use.")
@@ -403,8 +435,10 @@ func (b *Bot) handleChat(c tele.Context) error {
 	currentID := b.getCurrentProviderID()
 	switch currentID {
 	case "gemini":
-		if _, ok := b.geminiMgr.Active(); ok {
-			mgr = b.geminiMgr
+		if b.geminiMgr != nil {
+			if _, ok := b.geminiMgr.Active(); ok {
+				mgr = b.geminiMgr
+			}
 		}
 	case "codex":
 		if _, ok := b.codexMgr.Active(); ok {
@@ -414,12 +448,18 @@ func (b *Bot) handleChat(c tele.Context) error {
 
 	// Fallback logic if currentProviderID is not set or session is gone
 	if mgr == nil {
-		if _, ok := b.geminiMgr.Active(); ok {
-			mgr = b.geminiMgr
-			b.setCurrentProviderID("gemini")
-		} else if _, ok = b.codexMgr.Active(); ok {
-			mgr = b.codexMgr
-			b.setCurrentProviderID("codex")
+		if b.geminiMgr != nil {
+			if _, ok := b.geminiMgr.Active(); ok {
+				mgr = b.geminiMgr
+				b.setCurrentProviderID("gemini")
+			}
+		}
+		if mgr == nil {
+			if sess, ok := b.codexMgr.Active(); ok {
+				mgr = b.codexMgr
+				b.setCurrentProviderID("codex")
+				_ = sess // satisfy unused
+			}
 		}
 	}
 
@@ -494,9 +534,14 @@ func (b *Bot) handleCallback(c tele.Context) error {
 		if _, ok := b.codexMgr.GetSession(id); ok {
 			sess, err = b.codexMgr.SetActive(id)
 			providerID = "codex"
-		} else {
-			sess, err = b.geminiMgr.SetActive(id)
-			providerID = "gemini"
+		} else if b.geminiMgr != nil {
+			if _, ok := b.geminiMgr.GetSession(id); ok {
+				sess, err = b.geminiMgr.SetActive(id)
+				providerID = "gemini"
+			}
+		}
+		if sess == nil {
+			return c.Send(fmt.Sprintf("Session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
 		}
 		if err != nil {
 			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
@@ -509,10 +554,18 @@ func (b *Bot) handleCallback(c tele.Context) error {
 		}
 		id := parts[1]
 		var err error
+		var found bool
 		if _, ok := b.codexMgr.GetSession(id); ok {
 			err = b.codexMgr.DeleteSession(id)
-		} else {
-			err = b.geminiMgr.DeleteSession(id)
+			found = true
+		} else if b.geminiMgr != nil {
+			if _, ok := b.geminiMgr.GetSession(id); ok {
+				err = b.geminiMgr.DeleteSession(id)
+				found = true
+			}
+		}
+		if !found {
+			return c.Send(fmt.Sprintf("Session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
 		}
 		if err != nil {
 			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
@@ -540,24 +593,28 @@ func (b *Bot) handleCallback(c tele.Context) error {
 }
 
 func (b *Bot) sendProviderPicker(c tele.Context, page int, text string) error {
-	markup := &tele.ReplyMarkup{}
-	markup.InlineKeyboard = [][]tele.InlineButton{
-		{
-			{Text: "Codex", Data: "p-pick:codex:browse"},
-			{Text: "Gemini", Data: "p-pick:gemini:browse"},
-		},
+	buttons := []tele.InlineButton{
+		{Text: "Codex", Data: "p-pick:codex:browse"},
 	}
+	if b.geminiMgr != nil {
+		buttons = append(buttons, tele.InlineButton{Text: "Gemini", Data: "p-pick:gemini:browse"})
+	}
+
+	markup := &tele.ReplyMarkup{}
+	markup.InlineKeyboard = [][]tele.InlineButton{buttons}
 	return c.Send(text, markup, tele.ModeHTML)
 }
 
 func (b *Bot) sendProviderPickerForFolder(c tele.Context, index int, text string) error {
-	markup := &tele.ReplyMarkup{}
-	markup.InlineKeyboard = [][]tele.InlineButton{
-		{
-			{Text: "Codex", Data: fmt.Sprintf("p-pick:codex:%d", index)},
-			{Text: "Gemini", Data: fmt.Sprintf("p-pick:gemini:%d", index)},
-		},
+	buttons := []tele.InlineButton{
+		{Text: "Codex", Data: fmt.Sprintf("p-pick:codex:%d", index)},
 	}
+	if b.geminiMgr != nil {
+		buttons = append(buttons, tele.InlineButton{Text: "Gemini", Data: fmt.Sprintf("p-pick:gemini:%d", index)})
+	}
+
+	markup := &tele.ReplyMarkup{}
+	markup.InlineKeyboard = [][]tele.InlineButton{buttons}
 	return c.Send(text, markup, tele.ModeHTML)
 }
 
@@ -580,8 +637,10 @@ func (b *Bot) handleProviderPick(c tele.Context, provider, indexStr string) erro
 	var sess *chat.Session
 	if provider == "codex" {
 		sess, err = b.codexMgr.CreateSession(resolvedFolder)
-	} else {
+	} else if b.geminiMgr != nil && provider == "gemini" {
 		sess, err = b.geminiMgr.CreateSession(resolvedFolder)
+	} else {
+		return c.Send("Provider not available.", tele.ModeHTML)
 	}
 
 	if err != nil {
@@ -633,7 +692,9 @@ func (b *Bot) handleChatNavigation(c tele.Context, data string) error {
 func (b *Bot) sendSessionPicker(c tele.Context, action, text string) error {
 	var sessions []*chat.Session
 	sessions = append(sessions, b.codexMgr.ListSessions()...)
-	sessions = append(sessions, b.geminiMgr.ListSessions()...)
+	if b.geminiMgr != nil {
+		sessions = append(sessions, b.geminiMgr.ListSessions()...)
+	}
 
 	if len(sessions) == 0 {
 		return c.Send("No chat sessions yet.")

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"html"
+	"strconv"
 	"strings"
 	"time"
 
@@ -197,13 +198,13 @@ After creating a Codex session, send a normal text message and it will go to Cod
 func (b *Bot) handleNew(c tele.Context) error {
 	folder := strings.TrimSpace(c.Message().Payload)
 	if folder == "" {
-		return b.sendCodexFolderPicker(c, 0, "<b>Select a repository for a new Codex session</b>")
+		return b.sendProviderPicker(c, 0, "<b>Select a provider for a new chat session</b>")
 	}
 
 	resolved, matches := botutil.MatchFolderQuery(b.listGitFolders(), folder)
 	switch {
 	case resolved != "":
-		return b.createSession(c, resolved)
+		return b.sendProviderPickerForFolder(c, resolved, "<b>Select a provider for <code>"+html.EscapeString(resolved)+"</code></b>")
 	case len(matches) == 0:
 		return c.Send(fmt.Sprintf("No project matched <code>%s</code>.", html.EscapeString(folder)), tele.ModeHTML)
 	default:
@@ -223,49 +224,66 @@ func (b *Bot) handleFolders(c tele.Context) error {
 }
 
 func (b *Bot) handleSessions(c tele.Context) error {
-	sessions := b.codexMgr.ListSessions()
+	var sessions []*chat.Session
+	sessions = append(sessions, b.codexMgr.ListSessions()...)
+	sessions = append(sessions, b.geminiMgr.ListSessions()...)
+
 	if len(sessions) == 0 {
-		return c.Send("No Codex sessions yet. Use /new.")
+		return c.Send("No chat sessions yet. Use /new.")
 	}
 
-	active, _ := b.codexMgr.Active()
+	activeCodex, _ := b.codexMgr.Active()
+	activeGemini, _ := b.geminiMgr.Active()
+
 	var sb strings.Builder
-	sb.WriteString("<b>Codex sessions</b>\n")
+	sb.WriteString("<b>Chat sessions</b>\n")
 	for _, sess := range sessions {
-		marker := " "
-		if active != nil && active.ID == sess.ID {
-			marker = "*"
+		providerID := "codex"
+		isActive := activeCodex != nil && activeCodex.ID == sess.ID
+		if _, ok := b.geminiMgr.GetSession(sess.ID); ok {
+			providerID = "gemini"
+			isActive = activeGemini != nil && activeGemini.ID == sess.ID
 		}
-		thread := "new"
-		if sess.ThreadID != "" {
-			thread = "live"
+
+		marker := " "
+		if isActive {
+			marker = "*"
 		}
 		sb.WriteString(fmt.Sprintf(
 			"%s <code>%s</code> | <code>%s</code> | %s\n",
 			marker,
 			html.EscapeString(sess.ID),
 			html.EscapeString(sess.RelName),
-			thread,
+			providerID,
 		))
 	}
 
-	return c.Send(sb.String(), b.codexSessionPickerMarkup(sessions), tele.ModeHTML)
+	return c.Send(sb.String(), b.sessionPickerMarkup(sessions), tele.ModeHTML)
 }
 
 func (b *Bot) handleUse(c tele.Context) error {
 	id := strings.TrimSpace(c.Message().Payload)
 	if id == "" {
-		return b.sendCodexSessionPicker(c, "cuse", "<b>Select the active session</b>")
+		return b.sendSessionPicker(c, "use", "<b>Select the active session</b>")
 	}
 
-	sess, err := b.codexMgr.SetActive(id)
+	var sess *chat.Session
+	var err error
+	if _, ok := b.codexMgr.GetSession(id); ok {
+		sess, err = b.codexMgr.SetActive(id)
+	} else if _, ok = b.geminiMgr.GetSession(id); ok {
+		sess, err = b.geminiMgr.SetActive(id)
+	} else {
+		return c.Send(fmt.Sprintf("Session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
+	}
+
 	if err != nil {
 		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 	}
 
 	return c.Send(
 		fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)),
-		b.codexSessionActions(sess),
+		b.sessionActions(sess),
 		tele.ModeHTML,
 	)
 }
@@ -273,32 +291,41 @@ func (b *Bot) handleUse(c tele.Context) error {
 func (b *Bot) handleClose(c tele.Context) error {
 	id := strings.TrimSpace(c.Message().Payload)
 	if id == "" {
-		return b.sendCodexSessionPicker(c, "cclose", "<b>Select a session to close</b>")
+		return b.sendSessionPicker(c, "close", "<b>Select a session to close</b>")
 	}
 
-	if err := b.codexMgr.DeleteSession(id); err != nil {
+	var err error
+	if _, ok := b.codexMgr.GetSession(id); ok {
+		err = b.codexMgr.DeleteSession(id)
+	} else if _, ok = b.geminiMgr.GetSession(id); ok {
+		err = b.geminiMgr.DeleteSession(id)
+	} else {
+		return c.Send(fmt.Sprintf("Session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
+	}
+
+	if err != nil {
 		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 	}
 	return c.Send(fmt.Sprintf("Closed session <code>%s</code>.", html.EscapeString(id)), tele.ModeHTML)
 }
 
 func (b *Bot) handleCurrent(c tele.Context) error {
-	sess, ok := b.codexMgr.Active()
-	if !ok {
+	activeCodex, hasCodex := b.codexMgr.Active()
+	activeGemini, hasGemini := b.geminiMgr.Active()
+
+	if !hasCodex && !hasGemini {
 		return c.Send("No active session. Use /new or /use.")
 	}
 
-	thread := "not started"
-	if sess.ThreadID != "" {
-		thread = sess.ThreadID
+	var sb strings.Builder
+	if hasCodex {
+		sb.WriteString(fmt.Sprintf("<b>Active Codex</b>: <code>%s</code> in <code>%s</code>\n", html.EscapeString(activeCodex.ID), html.EscapeString(activeCodex.RelName)))
 	}
-	msg := fmt.Sprintf(
-		"<b>Active session</b>\nID: <code>%s</code>\nProject: <code>%s</code>\nThread: <code>%s</code>",
-		html.EscapeString(sess.ID),
-		html.EscapeString(sess.RelName),
-		html.EscapeString(thread),
-	)
-	return c.Send(msg, b.codexSessionActions(sess), tele.ModeHTML)
+	if hasGemini {
+		sb.WriteString(fmt.Sprintf("<b>Active Gemini</b>: <code>%s</code> in <code>%s</code>\n", html.EscapeString(activeGemini.ID), html.EscapeString(activeGemini.RelName)))
+	}
+
+	return c.Send(sb.String(), tele.ModeHTML)
 }
 
 func (b *Bot) handleChat(c tele.Context) error {
@@ -310,19 +337,34 @@ func (b *Bot) handleChat(c tele.Context) error {
 		return nil
 	}
 
-	sess, err := b.codexMgr.ResolveActive()
+	// Default to Gemini if active, then fallback to Codex
+	var mgr chatProvider
+	if _, ok := b.geminiMgr.Active(); ok {
+		mgr = b.geminiMgr
+	} else if _, ok = b.codexMgr.Active(); ok {
+		mgr = b.codexMgr
+	} else {
+		return c.Send("No active chat session. Use /new or /use.")
+	}
+
+	sess, err := mgr.ResolveActive()
 	if err != nil {
 		return c.Send(err.Error())
 	}
 
 	_ = c.Notify(tele.Typing)
-	replySession, response, err := b.codexMgr.Send(context.Background(), sess.ID, msg.Text, nil)
+	replySession, response, err := mgr.Send(context.Background(), sess.ID, msg.Text, nil)
 	if err != nil {
 		return c.Send(err.Error())
 	}
 
 	header := fmt.Sprintf("[%s | %s]\n", replySession.ID, replySession.RelName)
 	return b.sendTextChunks(c, header+response)
+}
+
+type chatProvider interface {
+	ResolveActive() (*chat.Session, error)
+	Send(ctx context.Context, id, prompt string, attachments []chat.Attachment) (*chat.Session, string, error)
 }
 
 func (b *Bot) handleCallback(c tele.Context) error {
@@ -349,29 +391,48 @@ func (b *Bot) handleCallback(c tele.Context) error {
 		if len(parts) != 2 {
 			return nil
 		}
-		return b.handleCodexFolderPick(c, parts[1])
+		return b.handleChatFolderPickLegacy(c, parts[1])
 	case "cnav":
 		if len(parts) != 2 {
 			return nil
 		}
-		return b.handleCodexNavigation(c, parts[1])
-	case "cuse":
+		return b.handleChatNavigation(c, parts[1])
+	case "p-pick":
+		if len(parts) != 3 {
+			return nil
+		}
+		return b.handleProviderPick(c, parts[1], parts[2])
+	case "use":
 		if len(parts) != 2 {
 			return nil
 		}
-		sess, err := b.codexMgr.SetActive(parts[1])
+		id := parts[1]
+		var sess *chat.Session
+		var err error
+		if _, ok := b.codexMgr.GetSession(id); ok {
+			sess, err = b.codexMgr.SetActive(id)
+		} else {
+			sess, err = b.geminiMgr.SetActive(id)
+		}
 		if err != nil {
 			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 		}
-		return c.Send(fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)), b.codexSessionActions(sess), tele.ModeHTML)
-	case "cclose":
+		return c.Send(fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)), b.sessionActions(sess), tele.ModeHTML)
+	case "close":
 		if len(parts) != 2 {
 			return nil
 		}
-		if err := b.codexMgr.DeleteSession(parts[1]); err != nil {
+		id := parts[1]
+		var err error
+		if _, ok := b.codexMgr.GetSession(id); ok {
+			err = b.codexMgr.DeleteSession(id)
+		} else {
+			err = b.geminiMgr.DeleteSession(id)
+		}
+		if err != nil {
 			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 		}
-		return c.Send(fmt.Sprintf("Closed session <code>%s</code>.", html.EscapeString(parts[1])), tele.ModeHTML)
+		return c.Send(fmt.Sprintf("Closed session <code>%s</code>.", html.EscapeString(id)), tele.ModeHTML)
 	case "start", "kill", "status", "logs", "restart":
 		if len(parts) != 2 {
 			return nil
@@ -393,21 +454,128 @@ func (b *Bot) handleCallback(c tele.Context) error {
 	return nil
 }
 
-func (b *Bot) createSession(c tele.Context, folder string) error {
-	sess, err := b.codexMgr.CreateSession(folder)
+func (b *Bot) sendProviderPicker(c tele.Context, page int, text string) error {
+	markup := &tele.ReplyMarkup{}
+	markup.InlineKeyboard = [][]tele.InlineButton{
+		{
+			{Text: "Codex", Data: "p-pick:codex:browse"},
+			{Text: "Gemini", Data: "p-pick:gemini:browse"},
+		},
+	}
+	return c.Send(text, markup, tele.ModeHTML)
+}
+
+func (b *Bot) sendProviderPickerForFolder(c tele.Context, folder string, text string) error {
+	markup := &tele.ReplyMarkup{}
+	markup.InlineKeyboard = [][]tele.InlineButton{
+		{
+			{Text: "Codex", Data: "p-pick:codex:" + folder},
+			{Text: "Gemini", Data: "p-pick:gemini:" + folder},
+		},
+	}
+	return c.Send(text, markup, tele.ModeHTML)
+}
+
+func (b *Bot) handleProviderPick(c tele.Context, provider, folder string) error {
+	if folder == "browse" {
+		return b.sendChatFolderPicker(c, provider, 0, "<b>Select a repository for <code>"+provider+"</code></b>")
+	}
+
+	var sess *chat.Session
+	var err error
+	if provider == "codex" {
+		sess, err = b.codexMgr.CreateSession(folder)
+	} else {
+		sess, err = b.geminiMgr.CreateSession(folder)
+	}
+
 	if err != nil {
 		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 	}
 
 	msg := fmt.Sprintf(
-		"<b>Codex session created</b>\nID: <code>%s</code>\nProject: <code>%s</code>\n\nSend a normal text message now and I will forward it to Codex.",
+		"<b>%s session created</b>\nID: <code>%s</code>\nProject: <code>%s</code>\n\nSend text to chat.",
+		strings.Title(provider),
 		html.EscapeString(sess.ID),
 		html.EscapeString(sess.RelName),
 	)
-	return c.Send(msg, b.codexSessionActions(sess), tele.ModeHTML)
+	return c.Send(msg, b.sessionActions(sess), tele.ModeHTML)
 }
 
-// Claude folder picker — uses pick:{action}:{index} / nav:{action}:{page} callbacks.
+func (b *Bot) sendChatFolderPicker(c tele.Context, provider string, page int, text string) error {
+	folders := b.listGitFolders()
+	if len(folders) == 0 {
+		return c.Send("No git repositories found.")
+	}
+
+	markup := botutil.FolderPickerMarkup(botutil.FolderPickerConfig{
+		Folders:  folders,
+		Page:     page,
+		PickData: func(index int) string { return fmt.Sprintf("p-pick:%s:%s", provider, folders[index]) },
+		NavData:  func(p int) string { return fmt.Sprintf("cnav:%s:%d", provider, p) },
+		Label:    func(folder string) string { return "Repo " + folder },
+	})
+	return c.Send(text, markup, tele.ModeHTML)
+}
+
+func (b *Bot) handleChatFolderPickLegacy(c tele.Context, indexStr string) error {
+	// Fallback for old cpick format if needed, but new code uses p-pick
+	return nil
+}
+
+func (b *Bot) handleChatNavigation(c tele.Context, data string) error {
+	parts := strings.Split(data, ":")
+	if len(parts) != 2 {
+		return nil
+	}
+	provider := parts[0]
+	page, _ := strconv.Atoi(parts[1])
+	return b.sendChatFolderPicker(c, provider, page, "<b>Available repositories</b>\nTap to create a session.")
+}
+
+func (b *Bot) sendSessionPicker(c tele.Context, action, text string) error {
+	var sessions []*chat.Session
+	sessions = append(sessions, b.codexMgr.ListSessions()...)
+	sessions = append(sessions, b.geminiMgr.ListSessions()...)
+
+	if len(sessions) == 0 {
+		return c.Send("No chat sessions yet.")
+	}
+
+	var items []botutil.PickerItem
+	for _, sess := range sessions {
+		items = append(items, botutil.PickerItem{
+			Label: fmt.Sprintf("%s - %s", sess.ID, sess.RelName),
+			Data:  action + ":" + sess.ID,
+		})
+	}
+	return c.Send(text, botutil.PickerMarkup(items), tele.ModeHTML)
+}
+
+func (b *Bot) sessionActions(sess *chat.Session) *tele.ReplyMarkup {
+	markup := &tele.ReplyMarkup{}
+	markup.InlineKeyboard = [][]tele.InlineButton{
+		{
+			{Text: "Use", Data: "use:" + sess.ID},
+			{Text: "Close", Data: "close:" + sess.ID},
+		},
+	}
+	return markup
+}
+
+func (b *Bot) sessionPickerMarkup(sessions []*chat.Session) *tele.ReplyMarkup {
+	markup := &tele.ReplyMarkup{}
+	var rows [][]tele.InlineButton
+	for _, sess := range sessions {
+		rows = append(rows, []tele.InlineButton{
+			{Text: "Use " + sess.ID, Data: "use:" + sess.ID},
+			{Text: "Close", Data: "close:" + sess.ID},
+		})
+	}
+	markup.InlineKeyboard = rows
+	return markup
+}
+
 func (b *Bot) sendClaudeFolderPicker(c tele.Context, action string, page int, text string) error {
 	folders := b.listGitFolders()
 	if len(folders) == 0 {
@@ -422,39 +590,6 @@ func (b *Bot) sendClaudeFolderPicker(c tele.Context, action string, page int, te
 		Label:    func(folder string) string { return "📂 " + folder },
 	})
 	return c.Send(text, markup, tele.ModeHTML)
-}
-
-// Codex folder picker — uses cpick:{index} / cnav:{page} callbacks.
-func (b *Bot) sendCodexFolderPicker(c tele.Context, page int, text string) error {
-	folders := b.listGitFolders()
-	if len(folders) == 0 {
-		return c.Send("No git repositories found in the projects folder.")
-	}
-
-	markup := botutil.FolderPickerMarkup(botutil.FolderPickerConfig{
-		Folders:  folders,
-		Page:     page,
-		PickData: func(index int) string { return fmt.Sprintf("cpick:%d", index) },
-		NavData:  func(p int) string { return fmt.Sprintf("cnav:%d", p) },
-		Label:    func(folder string) string { return "Repo " + folder },
-	})
-	return c.Send(text, markup, tele.ModeHTML)
-}
-
-func (b *Bot) sendCodexSessionPicker(c tele.Context, action, text string) error {
-	sessions := b.codexMgr.ListSessions()
-	if len(sessions) == 0 {
-		return c.Send("No Codex sessions yet. Use /new.")
-	}
-
-	var items []botutil.PickerItem
-	for _, sess := range sessions {
-		items = append(items, botutil.PickerItem{
-			Label: fmt.Sprintf("%s - %s", sess.ID, sess.RelName),
-			Data:  action + ":" + sess.ID,
-		})
-	}
-	return c.Send(text, botutil.PickerMarkup(items), tele.ModeHTML)
 }
 
 func (b *Bot) sendClaudeSessionPicker(c tele.Context, action, text string) error {
@@ -495,46 +630,6 @@ func (b *Bot) handleClaudeNavigation(c tele.Context, action string, pageStr stri
 	page := 0
 	fmt.Sscanf(pageStr, "%d", &page)
 	return b.sendClaudeFolderPicker(c, action, page, "<b>Available projects</b>\nTap to start a Claude session.")
-}
-
-func (b *Bot) handleCodexFolderPick(c tele.Context, indexStr string) error {
-	folders := b.listGitFolders()
-	index := 0
-	fmt.Sscanf(indexStr, "%d", &index)
-	if index < 0 || index >= len(folders) {
-		return c.Send("That repository is no longer available. Refresh with /new.")
-	}
-	return b.createSession(c, folders[index])
-}
-
-func (b *Bot) handleCodexNavigation(c tele.Context, pageStr string) error {
-	page := 0
-	fmt.Sscanf(pageStr, "%d", &page)
-	return b.sendCodexFolderPicker(c, page, "<b>Available repositories</b>\nTap to create a Codex session.")
-}
-
-func (b *Bot) codexSessionActions(sess *chat.Session) *tele.ReplyMarkup {
-	markup := &tele.ReplyMarkup{}
-	markup.InlineKeyboard = [][]tele.InlineButton{
-		{
-			{Text: "Use", Data: "cuse:" + sess.ID},
-			{Text: "Close", Data: "cclose:" + sess.ID},
-		},
-	}
-	return markup
-}
-
-func (b *Bot) codexSessionPickerMarkup(sessions []*chat.Session) *tele.ReplyMarkup {
-	markup := &tele.ReplyMarkup{}
-	var rows [][]tele.InlineButton
-	for _, sess := range sessions {
-		rows = append(rows, []tele.InlineButton{
-			{Text: "Use " + sess.ID, Data: "cuse:" + sess.ID},
-			{Text: "Close", Data: "cclose:" + sess.ID},
-		})
-	}
-	markup.InlineKeyboard = rows
-	return markup
 }
 
 func (b *Bot) sendTextChunks(c tele.Context, text string) error {

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -2,13 +2,15 @@ package rcodbot
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"html"
+	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
-	"encoding/json"
 	"github.com/zevro-ai/remote-control-on-demand/internal/botutil"
 	"github.com/zevro-ai/remote-control-on-demand/internal/chat"
 	"github.com/zevro-ai/remote-control-on-demand/internal/codex"
@@ -16,7 +18,6 @@ import (
 	"github.com/zevro-ai/remote-control-on-demand/internal/provider"
 	"github.com/zevro-ai/remote-control-on-demand/internal/session"
 	tele "gopkg.in/telebot.v4"
-	"os"
 )
 
 // Notifier abstracts the Telegram bot for HTTP-only mode.
@@ -27,14 +28,16 @@ type Notifier interface {
 }
 
 type Bot struct {
-	tb                *tele.Bot
-	sessionMgr        *session.Manager
-	codexMgr          *codex.Manager
-	geminiMgr         *gemini.Manager
-	allowedUserID     int64
-	unsubSession      func()
+	tb            *tele.Bot
+	sessionMgr    *session.Manager
+	codexMgr      *codex.Manager
+	geminiMgr     *gemini.Manager
+	allowedUserID int64
+	unsubSession  func()
+	statePath     string
+
+	mu                sync.RWMutex
 	currentProviderID string
-	statePath         string
 }
 
 // NopBot returns a no-op Notifier for HTTP-only mode.
@@ -75,7 +78,20 @@ type botState struct {
 	CurrentProviderID string `json:"current_provider_id"`
 }
 
-func (b *Bot) saveState() {
+func (b *Bot) setCurrentProviderID(id string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.currentProviderID = id
+	b.saveStateLocked()
+}
+
+func (b *Bot) getCurrentProviderID() string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.currentProviderID
+}
+
+func (b *Bot) saveStateLocked() {
 	if b.statePath == "" {
 		return
 	}
@@ -97,7 +113,9 @@ func (b *Bot) loadState() {
 	}
 	var state botState
 	if err := json.Unmarshal(data, &state); err == nil {
+		b.mu.Lock()
 		b.currentProviderID = state.CurrentProviderID
+		b.mu.Unlock()
 	}
 }
 
@@ -146,49 +164,40 @@ func (b *Bot) registerHandlers() {
 }
 
 func (b *Bot) registerCommands() {
-	b.tb.SetCommands([]tele.Command{
-		{Text: "start", Description: "Start a Claude session"},
+	_ = b.tb.SetCommands([]tele.Command{
+		{Text: "start", Description: "Start Claude for a repo"},
 		{Text: "list", Description: "List Claude sessions"},
-		{Text: "kill", Description: "Stop a Claude session"},
-		{Text: "status", Description: "Show Claude session details"},
-		{Text: "logs", Description: "Show Claude session logs"},
-		{Text: "restart", Description: "Restart a Claude session"},
 		{Text: "folders", Description: "Browse repos for Claude"},
-		{Text: "new", Description: "Create a Codex session"},
-		{Text: "sessions", Description: "List Codex sessions"},
-		{Text: "use", Description: "Switch active Codex session"},
-		{Text: "close", Description: "Close a Codex session"},
-		{Text: "current", Description: "Show active Codex session"},
-		{Text: "help", Description: "Show all commands"},
+		{Text: "new", Description: "Create Codex or Gemini session"},
+		{Text: "sessions", Description: "List chat sessions"},
+		{Text: "current", Description: "Show active chat session"},
+		{Text: "help", Description: "Show help"},
 	})
 }
 
 func (b *Bot) sendWelcome() {
-	var sb strings.Builder
-	sb.WriteString("<b>RCOD bot is online</b>\n\n")
-	sb.WriteString("<b>Claude remote control</b>\n")
-	sb.WriteString("Use <code>/start</code>, <code>/list</code>, <code>/status</code>, <code>/logs</code>, <code>/restart</code>, <code>/kill</code>, or <code>/folders</code>.\n\n")
-	sb.WriteString("<b>Codex & Gemini chat</b>\n")
-	sb.WriteString("Use <code>/new repo</code> to create a session, then send plain text to chat with the agent in that repo.\n")
-	sb.WriteString("Use <code>/sessions</code>, <code>/use</code>, <code>/current</code>, and <code>/close</code> to manage chats.\n")
+	msg := `<b>RCOD + Codex & Gemini</b>
 
-	folders := b.listGitFolders()
-	if len(folders) > 0 {
-		sb.WriteString(fmt.Sprintf("\n\nFound <b>%d</b> git repo(s) under <code>%s</code>.", len(folders), html.EscapeString(b.baseFolder())))
-	}
-	if active, ok := b.codexMgr.Active(); ok {
-		sb.WriteString(fmt.Sprintf("\nCurrent Codex session: <code>%s</code> in <code>%s</code>", html.EscapeString(active.ID), html.EscapeString(active.RelName)))
-	}
-	if active, ok := b.geminiMgr.Active(); ok {
-		sb.WriteString(fmt.Sprintf("\nCurrent Gemini session: <code>%s</code> in <code>%s</code>", html.EscapeString(active.ID), html.EscapeString(active.RelName)))
-	}
-	b.SendMessage(sb.String())
+Remote Control On Demand with AI agents.
+
+<b>Claude remote control</b>
+/start repo
+/list
+/folders
+
+<b>Codex & Gemini chat</b>
+/new repo
+/sessions
+/current
+
+Send text to chat with the active agent.`
+	b.SendMessage(msg)
 }
 
 func (b *Bot) handleStart(c tele.Context) error {
 	folder := strings.TrimSpace(c.Message().Payload)
 	if folder == "" {
-		return b.sendClaudeFolderPicker(c, "start", 0, "<b>Select a project to start in Claude</b>")
+		return b.sendClaudeFolderPicker(c, "start", 0, "<b>Select a repository to start Claude</b>")
 	}
 
 	resolved, matches := botutil.MatchFolderQuery(b.listGitFolders(), folder)
@@ -200,13 +209,17 @@ func (b *Bot) handleStart(c tele.Context) error {
 	default:
 		return c.Send(
 			fmt.Sprintf(
-				"Multiple projects matched <code>%s</code>:\n%s\n\nUse <code>/start exact-name</code> or browse with <code>/folders</code>.",
+				"Multiple projects matched <code>%s</code>:\n%s\n\nUse <code>/start exact-name</code> or run <code>/folders</code> to browse.",
 				html.EscapeString(folder),
 				botutil.FormatCodeList(matches, 8),
 			),
 			tele.ModeHTML,
 		)
 	}
+}
+
+func (b *Bot) handleFolders(c tele.Context) error {
+	return b.sendClaudeFolderPicker(c, "start", 0, "<b>Available projects</b>\nTap to start a Claude session.")
 }
 
 func (b *Bot) handleHelp(c tele.Context) error {
@@ -254,10 +267,6 @@ func (b *Bot) handleNew(c tele.Context) error {
 			tele.ModeHTML,
 		)
 	}
-}
-
-func (b *Bot) handleFolders(c tele.Context) error {
-	return b.sendClaudeFolderPicker(c, "start", 0, "<b>Available projects</b>\nTap to start a Claude session.")
 }
 
 func (b *Bot) handleSessions(c tele.Context) error {
@@ -321,8 +330,7 @@ func (b *Bot) handleUse(c tele.Context) error {
 		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 	}
 
-	b.currentProviderID = providerID
-	b.saveState()
+	b.setCurrentProviderID(providerID)
 
 	return c.Send(
 		fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)),
@@ -381,7 +389,8 @@ func (b *Bot) handleChat(c tele.Context) error {
 	}
 
 	var mgr chatProvider
-	switch b.currentProviderID {
+	currentID := b.getCurrentProviderID()
+	switch currentID {
 	case "gemini":
 		if _, ok := b.geminiMgr.Active(); ok {
 			mgr = b.geminiMgr
@@ -396,10 +405,10 @@ func (b *Bot) handleChat(c tele.Context) error {
 	if mgr == nil {
 		if _, ok := b.geminiMgr.Active(); ok {
 			mgr = b.geminiMgr
-			b.currentProviderID = "gemini"
+			b.setCurrentProviderID("gemini")
 		} else if _, ok = b.codexMgr.Active(); ok {
 			mgr = b.codexMgr
-			b.currentProviderID = "codex"
+			b.setCurrentProviderID("codex")
 		}
 	}
 
@@ -481,8 +490,7 @@ func (b *Bot) handleCallback(c tele.Context) error {
 		if err != nil {
 			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 		}
-		b.currentProviderID = providerID
-		b.saveState()
+		b.setCurrentProviderID(providerID)
 		return c.Send(fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)), b.sessionActions(sess), tele.ModeHTML)
 	case "close":
 		if len(parts) != 2 {
@@ -580,8 +588,7 @@ func (b *Bot) handleProviderPick(c tele.Context, provider, folderOrIndex string)
 		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 	}
 
-	b.currentProviderID = provider
-	b.saveState()
+	b.setCurrentProviderID(provider)
 
 	msg := fmt.Sprintf(
 		"<b>%s session created</b>\nID: <code>%s</code>\nProject: <code>%s</code>\n\nSend text to chat.",

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zevro-ai/remote-control-on-demand/internal/chat"
 	"github.com/zevro-ai/remote-control-on-demand/internal/codex"
 	"github.com/zevro-ai/remote-control-on-demand/internal/gemini"
+	"github.com/zevro-ai/remote-control-on-demand/internal/provider"
 	"github.com/zevro-ai/remote-control-on-demand/internal/session"
 	tele "gopkg.in/telebot.v4"
 )
@@ -24,12 +25,13 @@ type Notifier interface {
 }
 
 type Bot struct {
-	tb            *tele.Bot
-	sessionMgr    *session.Manager
-	codexMgr      *codex.Manager
-	geminiMgr     *gemini.Manager
-	allowedUserID int64
-	unsubSession  func()
+	tb                *tele.Bot
+	sessionMgr        *session.Manager
+	codexMgr          *codex.Manager
+	geminiMgr         *gemini.Manager
+	allowedUserID     int64
+	unsubSession      func()
+	currentProviderID string
 }
 
 // NopBot returns a no-op Notifier for HTTP-only mode.
@@ -173,7 +175,7 @@ func (b *Bot) handleStart(c tele.Context) error {
 }
 
 func (b *Bot) handleHelp(c tele.Context) error {
-	msg := `<b>RCOD + Codex</b>
+	msg := `<b>RCOD + Codex & Gemini</b>
 
 <b>Claude remote control</b>
 <code>/start repo</code> start a Claude session
@@ -184,14 +186,14 @@ func (b *Bot) handleHelp(c tele.Context) error {
 <code>/restart id</code> restart a Claude session
 <code>/folders</code> browse repos for Claude
 
-<b>Codex chat</b>
-<code>/new repo</code> create a Codex session
-<code>/sessions</code> list Codex sessions
-<code>/use id</code> switch active Codex session
-<code>/close id</code> close a Codex session
-<code>/current</code> show active Codex session
+<b>Codex & Gemini chat</b>
+<code>/new repo</code> create a chat session
+<code>/sessions</code> list chat sessions
+<code>/use id</code> switch active chat session
+<code>/close id</code> close a chat session
+<code>/current</code> show active chat session
 
-After creating a Codex session, send a normal text message and it will go to Codex.`
+After creating a chat session, send a normal text message and it will go to the active agent.`
 	return c.Send(msg, tele.ModeHTML)
 }
 
@@ -269,10 +271,13 @@ func (b *Bot) handleUse(c tele.Context) error {
 
 	var sess *chat.Session
 	var err error
+	var providerID string
 	if _, ok := b.codexMgr.GetSession(id); ok {
 		sess, err = b.codexMgr.SetActive(id)
+		providerID = "codex"
 	} else if _, ok = b.geminiMgr.GetSession(id); ok {
 		sess, err = b.geminiMgr.SetActive(id)
+		providerID = "gemini"
 	} else {
 		return c.Send(fmt.Sprintf("Session <code>%s</code> not found.", html.EscapeString(id)), tele.ModeHTML)
 	}
@@ -280,6 +285,9 @@ func (b *Bot) handleUse(c tele.Context) error {
 	if err != nil {
 		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 	}
+
+	b.currentProviderID = providerID
+
 
 	return c.Send(
 		fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)),
@@ -337,13 +345,30 @@ func (b *Bot) handleChat(c tele.Context) error {
 		return nil
 	}
 
-	// Default to Gemini if active, then fallback to Codex
 	var mgr chatProvider
-	if _, ok := b.geminiMgr.Active(); ok {
-		mgr = b.geminiMgr
-	} else if _, ok = b.codexMgr.Active(); ok {
-		mgr = b.codexMgr
-	} else {
+	switch b.currentProviderID {
+	case "gemini":
+		if _, ok := b.geminiMgr.Active(); ok {
+			mgr = b.geminiMgr
+		}
+	case "codex":
+		if _, ok := b.codexMgr.Active(); ok {
+			mgr = b.codexMgr
+		}
+	}
+
+	// Fallback logic if currentProviderID is not set or session is gone
+	if mgr == nil {
+		if _, ok := b.geminiMgr.Active(); ok {
+			mgr = b.geminiMgr
+			b.currentProviderID = "gemini"
+		} else if _, ok = b.codexMgr.Active(); ok {
+			mgr = b.codexMgr
+			b.currentProviderID = "codex"
+		}
+	}
+
+	if mgr == nil {
 		return c.Send("No active chat session. Use /new or /use.")
 	}
 
@@ -358,11 +383,12 @@ func (b *Bot) handleChat(c tele.Context) error {
 		return c.Send(err.Error())
 	}
 
-	header := fmt.Sprintf("[%s | %s]\n", replySession.ID, replySession.RelName)
+	header := fmt.Sprintf("[%s | %s | %s]\n", mgr.Metadata().DisplayName, replySession.ID, replySession.RelName)
 	return b.sendTextChunks(c, header+response)
 }
 
 type chatProvider interface {
+	Metadata() provider.Metadata
 	ResolveActive() (*chat.Session, error)
 	Send(ctx context.Context, id, prompt string, attachments []chat.Attachment) (*chat.Session, string, error)
 }
@@ -409,14 +435,18 @@ func (b *Bot) handleCallback(c tele.Context) error {
 		id := parts[1]
 		var sess *chat.Session
 		var err error
+		var providerID string
 		if _, ok := b.codexMgr.GetSession(id); ok {
 			sess, err = b.codexMgr.SetActive(id)
+			providerID = "codex"
 		} else {
 			sess, err = b.geminiMgr.SetActive(id)
+			providerID = "gemini"
 		}
 		if err != nil {
 			return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 		}
+		b.currentProviderID = providerID
 		return c.Send(fmt.Sprintf("Active session: <code>%s</code> in <code>%s</code>", html.EscapeString(sess.ID), html.EscapeString(sess.RelName)), b.sessionActions(sess), tele.ModeHTML)
 	case "close":
 		if len(parts) != 2 {
@@ -493,6 +523,8 @@ func (b *Bot) handleProviderPick(c tele.Context, provider, folder string) error 
 		return c.Send(fmt.Sprintf("Error: <code>%s</code>", html.EscapeString(err.Error())), tele.ModeHTML)
 	}
 
+	b.currentProviderID = provider
+
 	msg := fmt.Sprintf(
 		"<b>%s session created</b>\nID: <code>%s</code>\nProject: <code>%s</code>\n\nSend text to chat.",
 		strings.Title(provider),
@@ -528,9 +560,9 @@ func (b *Bot) handleChatNavigation(c tele.Context, data string) error {
 	if len(parts) != 2 {
 		return nil
 	}
-	provider := parts[0]
+	providerID := parts[0]
 	page, _ := strconv.Atoi(parts[1])
-	return b.sendChatFolderPicker(c, provider, page, "<b>Available repositories</b>\nTap to create a session.")
+	return b.sendChatFolderPicker(c, providerID, page, "<b>Available repositories</b>\nTap to create a session.")
 }
 
 func (b *Bot) sendSessionPicker(c tele.Context, action, text string) error {

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -481,19 +481,17 @@ func (b *Bot) handleChat(c tele.Context) error {
 		}
 	}
 
-	// Fallback logic if currentProviderID is not set or session is gone
+	// Fallback logic if currentProviderID is not set or session is gone.
+	// We prefer Codex as it's typically more restricted/standard.
 	if mgr == nil {
-		if b.geminiMgr != nil {
-			if _, ok := b.geminiMgr.Active(); ok {
+		if sess, ok := b.codexMgr.Active(); ok {
+			mgr = b.codexMgr
+			b.setCurrentProviderID("codex")
+			_ = sess
+		} else if b.geminiMgr != nil {
+			if _, ok = b.geminiMgr.Active(); ok {
 				mgr = b.geminiMgr
 				b.setCurrentProviderID("gemini")
-			}
-		}
-		if mgr == nil {
-			if sess, ok := b.codexMgr.Active(); ok {
-				mgr = b.codexMgr
-				b.setCurrentProviderID("codex")
-				_ = sess
 			}
 		}
 	}

--- a/internal/rcodbot/bot.go
+++ b/internal/rcodbot/bot.go
@@ -418,10 +418,10 @@ func (b *Bot) handleCallback(c tele.Context) error {
 		}
 		return b.handleChatFolderPickLegacy(c, parts[1])
 	case "cnav":
-		if len(parts) != 2 {
+		if len(parts) < 2 {
 			return nil
 		}
-		return b.handleChatNavigation(c, parts[1])
+		return b.handleChatNavigation(c, strings.Join(parts[1:], ":"))
 	case "p-pick":
 		if len(parts) != 3 {
 			return nil
@@ -510,12 +510,20 @@ func (b *Bot) handleProviderPick(c tele.Context, provider, folder string) error 
 		return b.sendChatFolderPicker(c, provider, 0, "<b>Select a repository for <code>"+provider+"</code></b>")
 	}
 
+	folders := b.listGitFolders()
+	index := 0
+	fmt.Sscanf(folder, "%d", &index)
+	if index < 0 || index >= len(folders) {
+		return c.Send("That repository is no longer available. Refresh with /new.")
+	}
+	resolvedFolder := folders[index]
+
 	var sess *chat.Session
 	var err error
 	if provider == "codex" {
-		sess, err = b.codexMgr.CreateSession(folder)
+		sess, err = b.codexMgr.CreateSession(resolvedFolder)
 	} else {
-		sess, err = b.geminiMgr.CreateSession(folder)
+		sess, err = b.geminiMgr.CreateSession(resolvedFolder)
 	}
 
 	if err != nil {
@@ -542,7 +550,7 @@ func (b *Bot) sendChatFolderPicker(c tele.Context, provider string, page int, te
 	markup := botutil.FolderPickerMarkup(botutil.FolderPickerConfig{
 		Folders:  folders,
 		Page:     page,
-		PickData: func(index int) string { return fmt.Sprintf("p-pick:%s:%s", provider, folders[index]) },
+		PickData: func(index int) string { return fmt.Sprintf("p-pick:%s:%d", provider, index) },
 		NavData:  func(p int) string { return fmt.Sprintf("cnav:%s:%d", provider, p) },
 		Label:    func(folder string) string { return "Repo " + folder },
 	})


### PR DESCRIPTION
This PR introduces support for the Gemini CLI as a new chat provider in RCOD.

### Changes
- Implemented  in  supporting  output format.
- Added Gemini configuration options to  struct and YAML support.
- Registered Gemini chat provider in  entrypoint.
- Added Gemini support to Telegram bot interface.
- Added styling for Gemini agent badge in the dashboard.
- Included unit tests for the Gemini manager and output parser.