### PR TITLE
fix: make the new session mode switch easier to distinguish

### DIFF
--- a/app/src/components/CreateSessionModal.test.tsx
+++ b/app/src/components/CreateSessionModal.test.tsx
@@ -153,7 +153,17 @@ describe("CreateSessionModal", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Adopt existing/i }));
+    const newSessionButton = screen.getByRole("button", { name: /New session.*Start from a repository/i });
+    const adoptExistingButton = screen.getByRole("button", { name: /Adopt existing.*Attach a running thread/i });
+
+    expect(screen.getByText("Session mode")).toBeTruthy();
+    expect(newSessionButton.getAttribute("aria-pressed")).toBe("true");
+    expect(adoptExistingButton.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(adoptExistingButton);
+
+    expect(newSessionButton.getAttribute("aria-pressed")).toBe("false");
+    expect(adoptExistingButton.getAttribute("aria-pressed")).toBe("true");
 
     await waitFor(() => {
       expect(onLoadAdoptableSessions).toHaveBeenCalledWith("codex");

--- a/app/src/components/CreateSessionModal.tsx
+++ b/app/src/components/CreateSessionModal.tsx
@@ -150,19 +150,28 @@ export function CreateSessionModal({
         </div>
 
         {canAdoptExistingSessions && (
-          <div className="flex gap-2 mb-4">
-            <button
-              className={mode === "new" ? "is-active" : ""}
-              onClick={() => setMode("new")}
-            >
-              New session
-            </button>
-            <button
-              className={mode === "adopt" ? "is-active" : ""}
-              onClick={() => setMode("adopt")}
-            >
-              Adopt existing
-            </button>
+          <div className="modal-mode-switch-shell">
+            <div className="modal-mode-switch__label">Session mode</div>
+            <div className="modal-mode-switch" role="group" aria-label="Session mode">
+              <button
+                type="button"
+                className={mode === "new" ? "is-active" : ""}
+                aria-pressed={mode === "new"}
+                onClick={() => setMode("new")}
+              >
+                <span className="modal-mode-switch__title">New session</span>
+                <span className="modal-mode-switch__hint">Start from a repository</span>
+              </button>
+              <button
+                type="button"
+                className={mode === "adopt" ? "is-active" : ""}
+                aria-pressed={mode === "adopt"}
+                onClick={() => setMode("adopt")}
+              >
+                <span className="modal-mode-switch__title">Adopt existing</span>
+                <span className="modal-mode-switch__hint">Attach a running thread</span>
+              </button>
+            </div>
           </div>
         )}
 

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1672,6 +1672,84 @@ button {
   background: rgba(74, 222, 128, 0.08);
 }
 
+.modal-mode-switch-shell {
+  margin-bottom: 16px;
+}
+
+.modal-mode-switch__label {
+  margin-bottom: 8px;
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.modal-mode-switch {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  padding: 6px;
+  border: 1px solid rgba(58, 78, 66, 0.92);
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(10, 15, 12, 0.98), rgba(7, 11, 9, 0.98));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    0 10px 24px rgba(0, 0, 0, 0.18);
+}
+
+.modal-mode-switch button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  text-align: left;
+  transition:
+    background 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease,
+    transform 150ms ease;
+}
+
+.modal-mode-switch button:hover {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-text-primary);
+}
+
+.modal-mode-switch button.is-active {
+  border-color: rgba(74, 222, 128, 0.3);
+  background:
+    linear-gradient(180deg, rgba(74, 222, 128, 0.16), rgba(74, 222, 128, 0.08)),
+    rgba(15, 22, 18, 0.98);
+  color: var(--color-text-primary);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 8px 20px rgba(0, 0, 0, 0.16);
+}
+
+.modal-mode-switch__title {
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.modal-mode-switch__hint {
+  color: var(--color-text-muted);
+  font-size: 0.73rem;
+  line-height: 1.25;
+}
+
+.modal-mode-switch button.is-active .modal-mode-switch__hint {
+  color: rgba(226, 240, 232, 0.78);
+}
+
 .modal-cancel-button {
   margin-top: 12px;
   width: 100%;


### PR DESCRIPTION
## Summary
- restyle the `New session` / `Adopt existing` switch so it reads as a segmented control instead of inline text
- add clearer active/inactive states plus short hints for each mode
- cover the mode switch semantics in the modal tests

Closes #66

## Verification
- npm test
- npm run build