### PR TITLE
fix: prevent non-release SPA file disclosure from working directory

### DIFF
--- a/internal/httpapi/dashboard/assets_dev.go
+++ b/internal/httpapi/dashboard/assets_dev.go
@@ -7,10 +7,9 @@ import (
 	"os"
 )
 
-// FS returns an empty file system for local development
-// to avoid errors when dist folder is missing.
+// FS returns dashboard assets for non-release builds.
 func FS() fs.FS {
-	// You could also use os.DirFS("app/dist") here if you want
-	// to serve assets from disk during dev without embedding.
-	return os.DirFS(".")
+	// Limit static serving to dashboard build artifacts only.
+	// If app/dist is absent, the server will return 404 for SPA routes.
+	return os.DirFS("app/dist")
 }

--- a/internal/httpapi/dashboard/assets_dev_test.go
+++ b/internal/httpapi/dashboard/assets_dev_test.go
@@ -1,0 +1,14 @@
+//go:build !release
+
+package dashboard
+
+import (
+	"io/fs"
+	"testing"
+)
+
+func TestDevFSDoesNotExposeRepositoryRoot(t *testing.T) {
+	if _, err := fs.Stat(FS(), "go.mod"); err == nil {
+		t.Fatal("expected go.mod to be inaccessible from dashboard FS")
+	}
+}


### PR DESCRIPTION
### Motivation
- Non-release builds used `os.DirFS(".")`, which allowed the SPA handler to serve arbitrary files from the process working directory and bypass authentication for static routes.
- The SPA handler serves any existing file from the provided FS and the auth middleware only guards `/api` and `/ws`, creating an information disclosure risk.

### Description
- Change `internal/httpapi/dashboard/assets_dev.go` to return `os.DirFS("app/dist")` instead of `os.DirFS(".")` to limit static serving to dashboard artifacts only.
- Add `internal/httpapi/dashboard/assets_dev_test.go` (build tag `!release`) with `TestDevFSDoesNotExposeRepositoryRoot` to assert that repository-root files like `go.mod` are not accessible via `FS()`.

### Testing
- Ran `go test ./internal/httpapi/...` and the package tests completed successfully (`ok` for the httpapi packages).
- The added test `TestDevFSDoesNotExposeRepositoryRoot` ran as part of the test suite and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8008fa220832b9d4706bd49d514f3)